### PR TITLE
Add messages for mod flags

### DIFF
--- a/dist/pbjs_pb.d.ts
+++ b/dist/pbjs_pb.d.ts
@@ -8020,6 +8020,15 @@ export namespace NT {
 
         /** LobbyAction cRunOver */
         cRunOver?: (NT.IClientRunOver|null);
+
+        /** LobbyAction cRoomModFlagsUpdate */
+        cRoomModFlagsUpdate?: (NT.IClientModFlagsUpdate|null);
+
+        /** LobbyAction sRoomModFlagsUpdated */
+        sRoomModFlagsUpdated?: (NT.IServerModFlagsUpdated|null);
+
+        /** LobbyAction sRoomModFlagsUpdateFailed */
+        sRoomModFlagsUpdateFailed?: (NT.IServerModFlagsUpdateFailed|null);
     }
 
     /** Represents a LobbyAction. */
@@ -8121,8 +8130,17 @@ export namespace NT {
         /** LobbyAction cRunOver. */
         public cRunOver?: (NT.IClientRunOver|null);
 
+        /** LobbyAction cRoomModFlagsUpdate. */
+        public cRoomModFlagsUpdate?: (NT.IClientModFlagsUpdate|null);
+
+        /** LobbyAction sRoomModFlagsUpdated. */
+        public sRoomModFlagsUpdated?: (NT.IServerModFlagsUpdated|null);
+
+        /** LobbyAction sRoomModFlagsUpdateFailed. */
+        public sRoomModFlagsUpdateFailed?: (NT.IServerModFlagsUpdateFailed|null);
+
         /** LobbyAction action. */
-        public action?: ("cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver");
+        public action?: ("cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|"cRoomModFlagsUpdate"|"sRoomModFlagsUpdated"|"sRoomModFlagsUpdateFailed");
 
         /**
          * Creates a new LobbyAction instance using the specified properties.
@@ -10006,6 +10024,297 @@ export namespace NT {
 
         /**
          * Gets the default type url for ServerRoomFlagsUpdateFailed
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ClientModFlagsUpdate. */
+    interface IClientModFlagsUpdate {
+
+        /** ClientModFlagsUpdate modFlags */
+        modFlags?: ({ [k: string]: string }|null);
+    }
+
+    /** Represents a ClientModFlagsUpdate. */
+    class ClientModFlagsUpdate implements IClientModFlagsUpdate {
+
+        /**
+         * Constructs a new ClientModFlagsUpdate.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IClientModFlagsUpdate);
+
+        /** ClientModFlagsUpdate modFlags. */
+        public modFlags: { [k: string]: string };
+
+        /**
+         * Creates a new ClientModFlagsUpdate instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ClientModFlagsUpdate instance
+         */
+        public static create(properties?: NT.IClientModFlagsUpdate): NT.ClientModFlagsUpdate;
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @param message ClientModFlagsUpdate message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IClientModFlagsUpdate, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message, length delimited. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @param message ClientModFlagsUpdate message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IClientModFlagsUpdate, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ClientModFlagsUpdate;
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ClientModFlagsUpdate;
+
+        /**
+         * Verifies a ClientModFlagsUpdate message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ClientModFlagsUpdate message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ClientModFlagsUpdate
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ClientModFlagsUpdate;
+
+        /**
+         * Creates a plain object from a ClientModFlagsUpdate message. Also converts values to other types if specified.
+         * @param message ClientModFlagsUpdate
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ClientModFlagsUpdate, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ClientModFlagsUpdate to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ClientModFlagsUpdate
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ServerModFlagsUpdated. */
+    interface IServerModFlagsUpdated {
+
+        /** ServerModFlagsUpdated modFlags */
+        modFlags?: ({ [k: string]: string }|null);
+    }
+
+    /** Represents a ServerModFlagsUpdated. */
+    class ServerModFlagsUpdated implements IServerModFlagsUpdated {
+
+        /**
+         * Constructs a new ServerModFlagsUpdated.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IServerModFlagsUpdated);
+
+        /** ServerModFlagsUpdated modFlags. */
+        public modFlags: { [k: string]: string };
+
+        /**
+         * Creates a new ServerModFlagsUpdated instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ServerModFlagsUpdated instance
+         */
+        public static create(properties?: NT.IServerModFlagsUpdated): NT.ServerModFlagsUpdated;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @param message ServerModFlagsUpdated message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IServerModFlagsUpdated, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @param message ServerModFlagsUpdated message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IServerModFlagsUpdated, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ServerModFlagsUpdated;
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ServerModFlagsUpdated;
+
+        /**
+         * Verifies a ServerModFlagsUpdated message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ServerModFlagsUpdated message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ServerModFlagsUpdated
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ServerModFlagsUpdated;
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdated message. Also converts values to other types if specified.
+         * @param message ServerModFlagsUpdated
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ServerModFlagsUpdated, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ServerModFlagsUpdated to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdated
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ServerModFlagsUpdateFailed. */
+    interface IServerModFlagsUpdateFailed {
+
+        /** ServerModFlagsUpdateFailed reason */
+        reason?: (string|null);
+    }
+
+    /** Represents a ServerModFlagsUpdateFailed. */
+    class ServerModFlagsUpdateFailed implements IServerModFlagsUpdateFailed {
+
+        /**
+         * Constructs a new ServerModFlagsUpdateFailed.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IServerModFlagsUpdateFailed);
+
+        /** ServerModFlagsUpdateFailed reason. */
+        public reason: string;
+
+        /**
+         * Creates a new ServerModFlagsUpdateFailed instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ServerModFlagsUpdateFailed instance
+         */
+        public static create(properties?: NT.IServerModFlagsUpdateFailed): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @param message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IServerModFlagsUpdateFailed, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @param message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IServerModFlagsUpdateFailed, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Verifies a ServerModFlagsUpdateFailed message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ServerModFlagsUpdateFailed message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ServerModFlagsUpdateFailed
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdateFailed message. Also converts values to other types if specified.
+         * @param message ServerModFlagsUpdateFailed
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ServerModFlagsUpdateFailed, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ServerModFlagsUpdateFailed to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdateFailed
          * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
          * @returns The default type url
          */

--- a/dist/pbjs_pb.d.ts
+++ b/dist/pbjs_pb.d.ts
@@ -10030,11 +10030,18 @@ export namespace NT {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
+    /** ModFlagsListType enum. */
+    enum ModFlagsListType {
+        UNSPECIFIED = 0,
+        ALLOWED = 1,
+        DENIED = 2
+    }
+
     /** Properties of a ClientModFlagsUpdate. */
     interface IClientModFlagsUpdate {
 
         /** ClientModFlagsUpdate modFlags */
-        modFlags?: ({ [k: string]: string }|null);
+        modFlags?: ({ [k: string]: NT.ModFlagsListType }|null);
     }
 
     /** Represents a ClientModFlagsUpdate. */
@@ -10047,7 +10054,7 @@ export namespace NT {
         constructor(properties?: NT.IClientModFlagsUpdate);
 
         /** ClientModFlagsUpdate modFlags. */
-        public modFlags: { [k: string]: string };
+        public modFlags: { [k: string]: NT.ModFlagsListType };
 
         /**
          * Creates a new ClientModFlagsUpdate instance using the specified properties.
@@ -10131,7 +10138,7 @@ export namespace NT {
     interface IServerModFlagsUpdated {
 
         /** ServerModFlagsUpdated modFlags */
-        modFlags?: ({ [k: string]: string }|null);
+        modFlags?: ({ [k: string]: NT.ModFlagsListType }|null);
     }
 
     /** Represents a ServerModFlagsUpdated. */
@@ -10144,7 +10151,7 @@ export namespace NT {
         constructor(properties?: NT.IServerModFlagsUpdated);
 
         /** ServerModFlagsUpdated modFlags. */
-        public modFlags: { [k: string]: string };
+        public modFlags: { [k: string]: NT.ModFlagsListType };
 
         /**
          * Creates a new ServerModFlagsUpdated instance using the specified properties.

--- a/dist/pbjs_pb.js
+++ b/dist/pbjs_pb.js
@@ -19975,6 +19975,9 @@ $root.NT = (function() {
          * @property {NT.IServerDisconnected|null} [sDisconnected] LobbyAction sDisconnected
          * @property {NT.IServerRoomAddToList|null} [sRoomAddToList] LobbyAction sRoomAddToList
          * @property {NT.IClientRunOver|null} [cRunOver] LobbyAction cRunOver
+         * @property {NT.IClientModFlagsUpdate|null} [cRoomModFlagsUpdate] LobbyAction cRoomModFlagsUpdate
+         * @property {NT.IServerModFlagsUpdated|null} [sRoomModFlagsUpdated] LobbyAction sRoomModFlagsUpdated
+         * @property {NT.IServerModFlagsUpdateFailed|null} [sRoomModFlagsUpdateFailed] LobbyAction sRoomModFlagsUpdateFailed
          */
 
         /**
@@ -20232,17 +20235,41 @@ $root.NT = (function() {
          */
         LobbyAction.prototype.cRunOver = null;
 
+        /**
+         * LobbyAction cRoomModFlagsUpdate.
+         * @member {NT.IClientModFlagsUpdate|null|undefined} cRoomModFlagsUpdate
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.cRoomModFlagsUpdate = null;
+
+        /**
+         * LobbyAction sRoomModFlagsUpdated.
+         * @member {NT.IServerModFlagsUpdated|null|undefined} sRoomModFlagsUpdated
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.sRoomModFlagsUpdated = null;
+
+        /**
+         * LobbyAction sRoomModFlagsUpdateFailed.
+         * @member {NT.IServerModFlagsUpdateFailed|null|undefined} sRoomModFlagsUpdateFailed
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.sRoomModFlagsUpdateFailed = null;
+
         // OneOf field names bound to virtual getters and setters
         var $oneOfFields;
 
         /**
          * LobbyAction action.
-         * @member {"cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|undefined} action
+         * @member {"cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|"cRoomModFlagsUpdate"|"sRoomModFlagsUpdated"|"sRoomModFlagsUpdateFailed"|undefined} action
          * @memberof NT.LobbyAction
          * @instance
          */
         Object.defineProperty(LobbyAction.prototype, "action", {
-            get: $util.oneOfGetter($oneOfFields = ["cRoomCreate", "sRoomCreated", "sRoomCreateFailed", "cRoomUpdate", "sRoomUpdated", "sRoomUpdateFailed", "cRoomFlagsUpdate", "sRoomFlagsUpdated", "sRoomFlagsUpdateFailed", "cRoomDelete", "sRoomDeleted", "cJoinRoom", "sJoinRoomSuccess", "sJoinRoomFailed", "sUserJoinedRoom", "cLeaveRoom", "sUserLeftRoom", "cKickUser", "sUserKicked", "cBanUser", "sUserBanned", "cReadyState", "sUserReadyState", "cStartRun", "sHostStart", "cRequestRoomList", "sRoomList", "sDisconnected", "sRoomAddToList", "cRunOver"]),
+            get: $util.oneOfGetter($oneOfFields = ["cRoomCreate", "sRoomCreated", "sRoomCreateFailed", "cRoomUpdate", "sRoomUpdated", "sRoomUpdateFailed", "cRoomFlagsUpdate", "sRoomFlagsUpdated", "sRoomFlagsUpdateFailed", "cRoomDelete", "sRoomDeleted", "cJoinRoom", "sJoinRoomSuccess", "sJoinRoomFailed", "sUserJoinedRoom", "cLeaveRoom", "sUserLeftRoom", "cKickUser", "sUserKicked", "cBanUser", "sUserBanned", "cReadyState", "sUserReadyState", "cStartRun", "sHostStart", "cRequestRoomList", "sRoomList", "sDisconnected", "sRoomAddToList", "cRunOver", "cRoomModFlagsUpdate", "sRoomModFlagsUpdated", "sRoomModFlagsUpdateFailed"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -20330,6 +20357,12 @@ $root.NT = (function() {
                 $root.NT.ServerRoomAddToList.encode(message.sRoomAddToList, writer.uint32(/* id 32, wireType 2 =*/258).fork()).ldelim();
             if (message.cRunOver != null && Object.hasOwnProperty.call(message, "cRunOver"))
                 $root.NT.ClientRunOver.encode(message.cRunOver, writer.uint32(/* id 33, wireType 2 =*/266).fork()).ldelim();
+            if (message.cRoomModFlagsUpdate != null && Object.hasOwnProperty.call(message, "cRoomModFlagsUpdate"))
+                $root.NT.ClientModFlagsUpdate.encode(message.cRoomModFlagsUpdate, writer.uint32(/* id 34, wireType 2 =*/274).fork()).ldelim();
+            if (message.sRoomModFlagsUpdated != null && Object.hasOwnProperty.call(message, "sRoomModFlagsUpdated"))
+                $root.NT.ServerModFlagsUpdated.encode(message.sRoomModFlagsUpdated, writer.uint32(/* id 35, wireType 2 =*/282).fork()).ldelim();
+            if (message.sRoomModFlagsUpdateFailed != null && Object.hasOwnProperty.call(message, "sRoomModFlagsUpdateFailed"))
+                $root.NT.ServerModFlagsUpdateFailed.encode(message.sRoomModFlagsUpdateFailed, writer.uint32(/* id 36, wireType 2 =*/290).fork()).ldelim();
             return writer;
         };
 
@@ -20482,6 +20515,18 @@ $root.NT = (function() {
                     }
                 case 33: {
                         message.cRunOver = $root.NT.ClientRunOver.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 34: {
+                        message.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 35: {
+                        message.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 36: {
+                        message.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.decode(reader, reader.uint32());
                         break;
                     }
                 default:
@@ -20818,6 +20863,36 @@ $root.NT = (function() {
                         return "cRunOver." + error;
                 }
             }
+            if (message.cRoomModFlagsUpdate != null && message.hasOwnProperty("cRoomModFlagsUpdate")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ClientModFlagsUpdate.verify(message.cRoomModFlagsUpdate);
+                    if (error)
+                        return "cRoomModFlagsUpdate." + error;
+                }
+            }
+            if (message.sRoomModFlagsUpdated != null && message.hasOwnProperty("sRoomModFlagsUpdated")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ServerModFlagsUpdated.verify(message.sRoomModFlagsUpdated);
+                    if (error)
+                        return "sRoomModFlagsUpdated." + error;
+                }
+            }
+            if (message.sRoomModFlagsUpdateFailed != null && message.hasOwnProperty("sRoomModFlagsUpdateFailed")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ServerModFlagsUpdateFailed.verify(message.sRoomModFlagsUpdateFailed);
+                    if (error)
+                        return "sRoomModFlagsUpdateFailed." + error;
+                }
+            }
             return null;
         };
 
@@ -20982,6 +21057,21 @@ $root.NT = (function() {
                 if (typeof object.cRunOver !== "object")
                     throw TypeError(".NT.LobbyAction.cRunOver: object expected");
                 message.cRunOver = $root.NT.ClientRunOver.fromObject(object.cRunOver);
+            }
+            if (object.cRoomModFlagsUpdate != null) {
+                if (typeof object.cRoomModFlagsUpdate !== "object")
+                    throw TypeError(".NT.LobbyAction.cRoomModFlagsUpdate: object expected");
+                message.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.fromObject(object.cRoomModFlagsUpdate);
+            }
+            if (object.sRoomModFlagsUpdated != null) {
+                if (typeof object.sRoomModFlagsUpdated !== "object")
+                    throw TypeError(".NT.LobbyAction.sRoomModFlagsUpdated: object expected");
+                message.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.fromObject(object.sRoomModFlagsUpdated);
+            }
+            if (object.sRoomModFlagsUpdateFailed != null) {
+                if (typeof object.sRoomModFlagsUpdateFailed !== "object")
+                    throw TypeError(".NT.LobbyAction.sRoomModFlagsUpdateFailed: object expected");
+                message.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.fromObject(object.sRoomModFlagsUpdateFailed);
             }
             return message;
         };
@@ -21148,6 +21238,21 @@ $root.NT = (function() {
                 object.cRunOver = $root.NT.ClientRunOver.toObject(message.cRunOver, options);
                 if (options.oneofs)
                     object.action = "cRunOver";
+            }
+            if (message.cRoomModFlagsUpdate != null && message.hasOwnProperty("cRoomModFlagsUpdate")) {
+                object.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.toObject(message.cRoomModFlagsUpdate, options);
+                if (options.oneofs)
+                    object.action = "cRoomModFlagsUpdate";
+            }
+            if (message.sRoomModFlagsUpdated != null && message.hasOwnProperty("sRoomModFlagsUpdated")) {
+                object.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.toObject(message.sRoomModFlagsUpdated, options);
+                if (options.oneofs)
+                    object.action = "sRoomModFlagsUpdated";
+            }
+            if (message.sRoomModFlagsUpdateFailed != null && message.hasOwnProperty("sRoomModFlagsUpdateFailed")) {
+                object.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.toObject(message.sRoomModFlagsUpdateFailed, options);
+                if (options.oneofs)
+                    object.action = "sRoomModFlagsUpdateFailed";
             }
             return object;
         };
@@ -25554,6 +25659,685 @@ $root.NT = (function() {
         };
 
         return ServerRoomFlagsUpdateFailed;
+    })();
+
+    NT.ClientModFlagsUpdate = (function() {
+
+        /**
+         * Properties of a ClientModFlagsUpdate.
+         * @memberof NT
+         * @interface IClientModFlagsUpdate
+         * @property {Object.<string,string>|null} [modFlags] ClientModFlagsUpdate modFlags
+         */
+
+        /**
+         * Constructs a new ClientModFlagsUpdate.
+         * @memberof NT
+         * @classdesc Represents a ClientModFlagsUpdate.
+         * @implements IClientModFlagsUpdate
+         * @constructor
+         * @param {NT.IClientModFlagsUpdate=} [properties] Properties to set
+         */
+        function ClientModFlagsUpdate(properties) {
+            this.modFlags = {};
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ClientModFlagsUpdate modFlags.
+         * @member {Object.<string,string>} modFlags
+         * @memberof NT.ClientModFlagsUpdate
+         * @instance
+         */
+        ClientModFlagsUpdate.prototype.modFlags = $util.emptyObject;
+
+        /**
+         * Creates a new ClientModFlagsUpdate instance using the specified properties.
+         * @function create
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate=} [properties] Properties to set
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate instance
+         */
+        ClientModFlagsUpdate.create = function create(properties) {
+            return new ClientModFlagsUpdate(properties);
+        };
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate} message ClientModFlagsUpdate message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ClientModFlagsUpdate.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
+                for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message, length delimited. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate} message ClientModFlagsUpdate message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ClientModFlagsUpdate.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ClientModFlagsUpdate.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ClientModFlagsUpdate(), key, value;
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        if (message.modFlags === $util.emptyObject)
+                            message.modFlags = {};
+                        var end2 = reader.uint32() + reader.pos;
+                        key = "";
+                        value = "";
+                        while (reader.pos < end2) {
+                            var tag2 = reader.uint32();
+                            switch (tag2 >>> 3) {
+                            case 1:
+                                key = reader.string();
+                                break;
+                            case 2:
+                                value = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag2 & 7);
+                                break;
+                            }
+                        }
+                        message.modFlags[key] = value;
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ClientModFlagsUpdate.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ClientModFlagsUpdate message.
+         * @function verify
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ClientModFlagsUpdate.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.modFlags != null && message.hasOwnProperty("modFlags")) {
+                if (!$util.isObject(message.modFlags))
+                    return "modFlags: object expected";
+                var key = Object.keys(message.modFlags);
+                for (var i = 0; i < key.length; ++i)
+                    if (!$util.isString(message.modFlags[key[i]]))
+                        return "modFlags: string{k:string} expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a ClientModFlagsUpdate message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         */
+        ClientModFlagsUpdate.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ClientModFlagsUpdate)
+                return object;
+            var message = new $root.NT.ClientModFlagsUpdate();
+            if (object.modFlags) {
+                if (typeof object.modFlags !== "object")
+                    throw TypeError(".NT.ClientModFlagsUpdate.modFlags: object expected");
+                message.modFlags = {};
+                for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
+                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ClientModFlagsUpdate message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.ClientModFlagsUpdate} message ClientModFlagsUpdate
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ClientModFlagsUpdate.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.objects || options.defaults)
+                object.modFlags = {};
+            var keys2;
+            if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
+                object.modFlags = {};
+                for (var j = 0; j < keys2.length; ++j)
+                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this ClientModFlagsUpdate to JSON.
+         * @function toJSON
+         * @memberof NT.ClientModFlagsUpdate
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ClientModFlagsUpdate.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ClientModFlagsUpdate
+         * @function getTypeUrl
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ClientModFlagsUpdate.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ClientModFlagsUpdate";
+        };
+
+        return ClientModFlagsUpdate;
+    })();
+
+    NT.ServerModFlagsUpdated = (function() {
+
+        /**
+         * Properties of a ServerModFlagsUpdated.
+         * @memberof NT
+         * @interface IServerModFlagsUpdated
+         * @property {Object.<string,string>|null} [modFlags] ServerModFlagsUpdated modFlags
+         */
+
+        /**
+         * Constructs a new ServerModFlagsUpdated.
+         * @memberof NT
+         * @classdesc Represents a ServerModFlagsUpdated.
+         * @implements IServerModFlagsUpdated
+         * @constructor
+         * @param {NT.IServerModFlagsUpdated=} [properties] Properties to set
+         */
+        function ServerModFlagsUpdated(properties) {
+            this.modFlags = {};
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ServerModFlagsUpdated modFlags.
+         * @member {Object.<string,string>} modFlags
+         * @memberof NT.ServerModFlagsUpdated
+         * @instance
+         */
+        ServerModFlagsUpdated.prototype.modFlags = $util.emptyObject;
+
+        /**
+         * Creates a new ServerModFlagsUpdated instance using the specified properties.
+         * @function create
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated=} [properties] Properties to set
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated instance
+         */
+        ServerModFlagsUpdated.create = function create(properties) {
+            return new ServerModFlagsUpdated(properties);
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated} message ServerModFlagsUpdated message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdated.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
+                for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated} message ServerModFlagsUpdated message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdated.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdated.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ServerModFlagsUpdated(), key, value;
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        if (message.modFlags === $util.emptyObject)
+                            message.modFlags = {};
+                        var end2 = reader.uint32() + reader.pos;
+                        key = "";
+                        value = "";
+                        while (reader.pos < end2) {
+                            var tag2 = reader.uint32();
+                            switch (tag2 >>> 3) {
+                            case 1:
+                                key = reader.string();
+                                break;
+                            case 2:
+                                value = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag2 & 7);
+                                break;
+                            }
+                        }
+                        message.modFlags[key] = value;
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdated.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ServerModFlagsUpdated message.
+         * @function verify
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ServerModFlagsUpdated.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.modFlags != null && message.hasOwnProperty("modFlags")) {
+                if (!$util.isObject(message.modFlags))
+                    return "modFlags: object expected";
+                var key = Object.keys(message.modFlags);
+                for (var i = 0; i < key.length; ++i)
+                    if (!$util.isString(message.modFlags[key[i]]))
+                        return "modFlags: string{k:string} expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a ServerModFlagsUpdated message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         */
+        ServerModFlagsUpdated.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ServerModFlagsUpdated)
+                return object;
+            var message = new $root.NT.ServerModFlagsUpdated();
+            if (object.modFlags) {
+                if (typeof object.modFlags !== "object")
+                    throw TypeError(".NT.ServerModFlagsUpdated.modFlags: object expected");
+                message.modFlags = {};
+                for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
+                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdated message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.ServerModFlagsUpdated} message ServerModFlagsUpdated
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ServerModFlagsUpdated.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.objects || options.defaults)
+                object.modFlags = {};
+            var keys2;
+            if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
+                object.modFlags = {};
+                for (var j = 0; j < keys2.length; ++j)
+                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this ServerModFlagsUpdated to JSON.
+         * @function toJSON
+         * @memberof NT.ServerModFlagsUpdated
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ServerModFlagsUpdated.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdated
+         * @function getTypeUrl
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ServerModFlagsUpdated.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ServerModFlagsUpdated";
+        };
+
+        return ServerModFlagsUpdated;
+    })();
+
+    NT.ServerModFlagsUpdateFailed = (function() {
+
+        /**
+         * Properties of a ServerModFlagsUpdateFailed.
+         * @memberof NT
+         * @interface IServerModFlagsUpdateFailed
+         * @property {string|null} [reason] ServerModFlagsUpdateFailed reason
+         */
+
+        /**
+         * Constructs a new ServerModFlagsUpdateFailed.
+         * @memberof NT
+         * @classdesc Represents a ServerModFlagsUpdateFailed.
+         * @implements IServerModFlagsUpdateFailed
+         * @constructor
+         * @param {NT.IServerModFlagsUpdateFailed=} [properties] Properties to set
+         */
+        function ServerModFlagsUpdateFailed(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ServerModFlagsUpdateFailed reason.
+         * @member {string} reason
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @instance
+         */
+        ServerModFlagsUpdateFailed.prototype.reason = "";
+
+        /**
+         * Creates a new ServerModFlagsUpdateFailed instance using the specified properties.
+         * @function create
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed=} [properties] Properties to set
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed instance
+         */
+        ServerModFlagsUpdateFailed.create = function create(properties) {
+            return new ServerModFlagsUpdateFailed(properties);
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdateFailed.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.reason != null && Object.hasOwnProperty.call(message, "reason"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.reason);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdateFailed.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdateFailed.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ServerModFlagsUpdateFailed();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        message.reason = reader.string();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdateFailed.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ServerModFlagsUpdateFailed message.
+         * @function verify
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ServerModFlagsUpdateFailed.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.reason != null && message.hasOwnProperty("reason"))
+                if (!$util.isString(message.reason))
+                    return "reason: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a ServerModFlagsUpdateFailed message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         */
+        ServerModFlagsUpdateFailed.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ServerModFlagsUpdateFailed)
+                return object;
+            var message = new $root.NT.ServerModFlagsUpdateFailed();
+            if (object.reason != null)
+                message.reason = String(object.reason);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdateFailed message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.ServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ServerModFlagsUpdateFailed.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                object.reason = "";
+            if (message.reason != null && message.hasOwnProperty("reason"))
+                object.reason = message.reason;
+            return object;
+        };
+
+        /**
+         * Converts this ServerModFlagsUpdateFailed to JSON.
+         * @function toJSON
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ServerModFlagsUpdateFailed.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdateFailed
+         * @function getTypeUrl
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ServerModFlagsUpdateFailed.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ServerModFlagsUpdateFailed";
+        };
+
+        return ServerModFlagsUpdateFailed;
     })();
 
     NT.ClientJoinRoom = (function() {

--- a/dist/pbjs_pb.js
+++ b/dist/pbjs_pb.js
@@ -25661,13 +25661,29 @@ $root.NT = (function() {
         return ServerRoomFlagsUpdateFailed;
     })();
 
+    /**
+     * ModFlagsListType enum.
+     * @name NT.ModFlagsListType
+     * @enum {number}
+     * @property {number} UNSPECIFIED=0 UNSPECIFIED value
+     * @property {number} ALLOWED=1 ALLOWED value
+     * @property {number} DENIED=2 DENIED value
+     */
+    NT.ModFlagsListType = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "UNSPECIFIED"] = 0;
+        values[valuesById[1] = "ALLOWED"] = 1;
+        values[valuesById[2] = "DENIED"] = 2;
+        return values;
+    })();
+
     NT.ClientModFlagsUpdate = (function() {
 
         /**
          * Properties of a ClientModFlagsUpdate.
          * @memberof NT
          * @interface IClientModFlagsUpdate
-         * @property {Object.<string,string>|null} [modFlags] ClientModFlagsUpdate modFlags
+         * @property {Object.<string,NT.ModFlagsListType>|null} [modFlags] ClientModFlagsUpdate modFlags
          */
 
         /**
@@ -25688,7 +25704,7 @@ $root.NT = (function() {
 
         /**
          * ClientModFlagsUpdate modFlags.
-         * @member {Object.<string,string>} modFlags
+         * @member {Object.<string,NT.ModFlagsListType>} modFlags
          * @memberof NT.ClientModFlagsUpdate
          * @instance
          */
@@ -25720,7 +25736,7 @@ $root.NT = (function() {
                 writer = $Writer.create();
             if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
                 for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.modFlags[keys[i]]).ldelim();
             return writer;
         };
 
@@ -25760,7 +25776,7 @@ $root.NT = (function() {
                             message.modFlags = {};
                         var end2 = reader.uint32() + reader.pos;
                         key = "";
-                        value = "";
+                        value = 0;
                         while (reader.pos < end2) {
                             var tag2 = reader.uint32();
                             switch (tag2 >>> 3) {
@@ -25768,7 +25784,7 @@ $root.NT = (function() {
                                 key = reader.string();
                                 break;
                             case 2:
-                                value = reader.string();
+                                value = reader.int32();
                                 break;
                             default:
                                 reader.skipType(tag2 & 7);
@@ -25818,8 +25834,14 @@ $root.NT = (function() {
                     return "modFlags: object expected";
                 var key = Object.keys(message.modFlags);
                 for (var i = 0; i < key.length; ++i)
-                    if (!$util.isString(message.modFlags[key[i]]))
-                        return "modFlags: string{k:string} expected";
+                    switch (message.modFlags[key[i]]) {
+                    default:
+                        return "modFlags: enum value{k:string} expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
             }
             return null;
         };
@@ -25841,7 +25863,26 @@ $root.NT = (function() {
                     throw TypeError(".NT.ClientModFlagsUpdate.modFlags: object expected");
                 message.modFlags = {};
                 for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
-                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+                    switch (object.modFlags[keys[i]]) {
+                    default:
+                        if (typeof object.modFlags[keys[i]] === "number") {
+                            message.modFlags[keys[i]] = object.modFlags[keys[i]];
+                            break;
+                        }
+                        break;
+                    case "UNSPECIFIED":
+                    case 0:
+                        message.modFlags[keys[i]] = 0;
+                        break;
+                    case "ALLOWED":
+                    case 1:
+                        message.modFlags[keys[i]] = 1;
+                        break;
+                    case "DENIED":
+                    case 2:
+                        message.modFlags[keys[i]] = 2;
+                        break;
+                    }
             }
             return message;
         };
@@ -25865,7 +25906,7 @@ $root.NT = (function() {
             if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
                 object.modFlags = {};
                 for (var j = 0; j < keys2.length; ++j)
-                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+                    object.modFlags[keys2[j]] = options.enums === String ? $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] === undefined ? message.modFlags[keys2[j]] : $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] : message.modFlags[keys2[j]];
             }
             return object;
         };
@@ -25905,7 +25946,7 @@ $root.NT = (function() {
          * Properties of a ServerModFlagsUpdated.
          * @memberof NT
          * @interface IServerModFlagsUpdated
-         * @property {Object.<string,string>|null} [modFlags] ServerModFlagsUpdated modFlags
+         * @property {Object.<string,NT.ModFlagsListType>|null} [modFlags] ServerModFlagsUpdated modFlags
          */
 
         /**
@@ -25926,7 +25967,7 @@ $root.NT = (function() {
 
         /**
          * ServerModFlagsUpdated modFlags.
-         * @member {Object.<string,string>} modFlags
+         * @member {Object.<string,NT.ModFlagsListType>} modFlags
          * @memberof NT.ServerModFlagsUpdated
          * @instance
          */
@@ -25958,7 +25999,7 @@ $root.NT = (function() {
                 writer = $Writer.create();
             if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
                 for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.modFlags[keys[i]]).ldelim();
             return writer;
         };
 
@@ -25998,7 +26039,7 @@ $root.NT = (function() {
                             message.modFlags = {};
                         var end2 = reader.uint32() + reader.pos;
                         key = "";
-                        value = "";
+                        value = 0;
                         while (reader.pos < end2) {
                             var tag2 = reader.uint32();
                             switch (tag2 >>> 3) {
@@ -26006,7 +26047,7 @@ $root.NT = (function() {
                                 key = reader.string();
                                 break;
                             case 2:
-                                value = reader.string();
+                                value = reader.int32();
                                 break;
                             default:
                                 reader.skipType(tag2 & 7);
@@ -26056,8 +26097,14 @@ $root.NT = (function() {
                     return "modFlags: object expected";
                 var key = Object.keys(message.modFlags);
                 for (var i = 0; i < key.length; ++i)
-                    if (!$util.isString(message.modFlags[key[i]]))
-                        return "modFlags: string{k:string} expected";
+                    switch (message.modFlags[key[i]]) {
+                    default:
+                        return "modFlags: enum value{k:string} expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
             }
             return null;
         };
@@ -26079,7 +26126,26 @@ $root.NT = (function() {
                     throw TypeError(".NT.ServerModFlagsUpdated.modFlags: object expected");
                 message.modFlags = {};
                 for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
-                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+                    switch (object.modFlags[keys[i]]) {
+                    default:
+                        if (typeof object.modFlags[keys[i]] === "number") {
+                            message.modFlags[keys[i]] = object.modFlags[keys[i]];
+                            break;
+                        }
+                        break;
+                    case "UNSPECIFIED":
+                    case 0:
+                        message.modFlags[keys[i]] = 0;
+                        break;
+                    case "ALLOWED":
+                    case 1:
+                        message.modFlags[keys[i]] = 1;
+                        break;
+                    case "DENIED":
+                    case 2:
+                        message.modFlags[keys[i]] = 2;
+                        break;
+                    }
             }
             return message;
         };
@@ -26103,7 +26169,7 @@ $root.NT = (function() {
             if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
                 object.modFlags = {};
                 for (var j = 0; j < keys2.length; ++j)
-                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+                    object.modFlags[keys2[j]] = options.enums === String ? $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] === undefined ? message.modFlags[keys2[j]] : $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] : message.modFlags[keys2[j]];
             }
             return object;
         };

--- a/dist/pbjs_pb.json
+++ b/dist/pbjs_pb.json
@@ -2171,11 +2171,18 @@
             }
           }
         },
+        "ModFlagsListType": {
+          "values": {
+            "UNSPECIFIED": 0,
+            "ALLOWED": 1,
+            "DENIED": 2
+          }
+        },
         "ClientModFlagsUpdate": {
           "fields": {
             "modFlags": {
               "keyType": "string",
-              "type": "string",
+              "type": "ModFlagsListType",
               "id": 1
             }
           }
@@ -2184,7 +2191,7 @@
           "fields": {
             "modFlags": {
               "keyType": "string",
-              "type": "string",
+              "type": "ModFlagsListType",
               "id": 1
             }
           }

--- a/dist/pbjs_pb.json
+++ b/dist/pbjs_pb.json
@@ -1574,7 +1574,10 @@
                 "sRoomList",
                 "sDisconnected",
                 "sRoomAddToList",
-                "cRunOver"
+                "cRunOver",
+                "cRoomModFlagsUpdate",
+                "sRoomModFlagsUpdated",
+                "sRoomModFlagsUpdateFailed"
               ]
             }
           },
@@ -1698,6 +1701,18 @@
             "cRunOver": {
               "type": "ClientRunOver",
               "id": 33
+            },
+            "cRoomModFlagsUpdate": {
+              "type": "ClientModFlagsUpdate",
+              "id": 34
+            },
+            "sRoomModFlagsUpdated": {
+              "type": "ServerModFlagsUpdated",
+              "id": 35
+            },
+            "sRoomModFlagsUpdateFailed": {
+              "type": "ServerModFlagsUpdateFailed",
+              "id": 36
             }
           }
         },
@@ -2149,6 +2164,32 @@
           }
         },
         "ServerRoomFlagsUpdateFailed": {
+          "fields": {
+            "reason": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ClientModFlagsUpdate": {
+          "fields": {
+            "modFlags": {
+              "keyType": "string",
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ServerModFlagsUpdated": {
+          "fields": {
+            "modFlags": {
+              "keyType": "string",
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ServerModFlagsUpdateFailed": {
           "fields": {
             "reason": {
               "type": "string",

--- a/dist/pbreflect.d.ts
+++ b/dist/pbreflect.d.ts
@@ -1556,6 +1556,18 @@ declare const NT: {
                 type: string;
                 id: number;
             };
+            cRoomModFlagsUpdate: {
+                type: string;
+                id: number;
+            };
+            sRoomModFlagsUpdated: {
+                type: string;
+                id: number;
+            };
+            sRoomModFlagsUpdateFailed: {
+                type: string;
+                id: number;
+            };
         };
     };
     ClientRunOver: {
@@ -1967,6 +1979,32 @@ declare const NT: {
             };
         };
     };
+    ClientModFlagsUpdate: {
+        fields: {
+            modFlags: {
+                keyType: string;
+                type: string;
+                id: number;
+            };
+        };
+    };
+    ServerModFlagsUpdated: {
+        fields: {
+            modFlags: {
+                keyType: string;
+                type: string;
+                id: number;
+            };
+        };
+    };
+    ServerModFlagsUpdateFailed: {
+        fields: {
+            reason: {
+                type: string;
+                id: number;
+            };
+        };
+    };
     ClientJoinRoom: {
         oneofs: {
             _password: {
@@ -2360,5 +2398,5 @@ type MessageIds<T extends {
 } & unknown;
 export declare const Messages: MessageIds<typeof NT>;
 export declare const gameActions: ("cPlayerMove" | "sPlayerMoves" | "cPlayerUpdate" | "sPlayerUpdate" | "cPlayerUpdateInventory" | "sPlayerUpdateInventory" | "cHostItemBank" | "sHostItemBank" | "cHostUserTake" | "sHostUserTake" | "cHostUserTakeGold" | "sHostUserTakeGold" | "cPlayerAddGold" | "sPlayerAddGold" | "cPlayerTakeGold" | "sPlayerTakeGold" | "cPlayerAddItem" | "sPlayerAddItem" | "cPlayerTakeItem" | "sPlayerTakeItem" | "cPlayerPickup" | "sPlayerPickup" | "cNemesisAbility" | "sNemesisAbility" | "cNemesisPickupItem" | "sNemesisPickupItem" | "cChat" | "sChat" | "cPlayerDeath" | "sPlayerDeath" | "cPlayerNewGamePlus" | "sPlayerNewGamePlus" | "cPlayerSecretHourglass" | "sPlayerSecretHourglass" | "cCustomModEvent" | "sCustomModEvent" | "cRespawnPenalty" | "sRespawnPenalty" | "cAngerySteve" | "sAngerySteve" | "sStatUpdate")[];
-export declare const lobbyActions: ("cRoomCreate" | "sRoomCreated" | "sRoomCreateFailed" | "cRoomUpdate" | "sRoomUpdated" | "sRoomUpdateFailed" | "cRoomFlagsUpdate" | "sRoomFlagsUpdated" | "sRoomFlagsUpdateFailed" | "cRoomDelete" | "sRoomDeleted" | "cJoinRoom" | "sJoinRoomSuccess" | "sJoinRoomFailed" | "sUserJoinedRoom" | "cLeaveRoom" | "sUserLeftRoom" | "cKickUser" | "sUserKicked" | "cBanUser" | "sUserBanned" | "cReadyState" | "sUserReadyState" | "cStartRun" | "sHostStart" | "cRequestRoomList" | "sRoomList" | "sDisconnected" | "sRoomAddToList" | "cRunOver")[];
+export declare const lobbyActions: ("cRoomCreate" | "sRoomCreated" | "sRoomCreateFailed" | "cRoomUpdate" | "sRoomUpdated" | "sRoomUpdateFailed" | "cRoomFlagsUpdate" | "sRoomFlagsUpdated" | "sRoomFlagsUpdateFailed" | "cRoomDelete" | "sRoomDeleted" | "cJoinRoom" | "sJoinRoomSuccess" | "sJoinRoomFailed" | "sUserJoinedRoom" | "cLeaveRoom" | "sUserLeftRoom" | "cKickUser" | "sUserKicked" | "cBanUser" | "sUserBanned" | "cReadyState" | "sUserReadyState" | "cStartRun" | "sHostStart" | "cRequestRoomList" | "sRoomList" | "sDisconnected" | "sRoomAddToList" | "cRunOver" | "cRoomModFlagsUpdate" | "sRoomModFlagsUpdated" | "sRoomModFlagsUpdateFailed")[];
 export {};

--- a/dist/pbreflect.d.ts
+++ b/dist/pbreflect.d.ts
@@ -1,2402 +1,458 @@
-declare const NT: {
+export declare const Messages: {
     Envelope: {
-        oneofs: {
-            kind: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            gameAction: {
-                type: string;
-                id: number;
-            };
-            lobbyAction: {
-                type: string;
-                id: number;
-            };
-        };
+        gameAction: number;
+        lobbyAction: number;
     };
     GameAction: {
-        oneofs: {
-            action: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            cPlayerMove: {
-                type: string;
-                id: number;
-            };
-            sPlayerMoves: {
-                type: string;
-                id: number;
-            };
-            cPlayerUpdate: {
-                type: string;
-                id: number;
-            };
-            sPlayerUpdate: {
-                type: string;
-                id: number;
-            };
-            cPlayerUpdateInventory: {
-                type: string;
-                id: number;
-            };
-            sPlayerUpdateInventory: {
-                type: string;
-                id: number;
-            };
-            cHostItemBank: {
-                type: string;
-                id: number;
-            };
-            sHostItemBank: {
-                type: string;
-                id: number;
-            };
-            cHostUserTake: {
-                type: string;
-                id: number;
-            };
-            sHostUserTake: {
-                type: string;
-                id: number;
-            };
-            cHostUserTakeGold: {
-                type: string;
-                id: number;
-            };
-            sHostUserTakeGold: {
-                type: string;
-                id: number;
-            };
-            cPlayerAddGold: {
-                type: string;
-                id: number;
-            };
-            sPlayerAddGold: {
-                type: string;
-                id: number;
-            };
-            cPlayerTakeGold: {
-                type: string;
-                id: number;
-            };
-            sPlayerTakeGold: {
-                type: string;
-                id: number;
-            };
-            cPlayerAddItem: {
-                type: string;
-                id: number;
-            };
-            sPlayerAddItem: {
-                type: string;
-                id: number;
-            };
-            cPlayerTakeItem: {
-                type: string;
-                id: number;
-            };
-            sPlayerTakeItem: {
-                type: string;
-                id: number;
-            };
-            cPlayerPickup: {
-                type: string;
-                id: number;
-            };
-            sPlayerPickup: {
-                type: string;
-                id: number;
-            };
-            cNemesisAbility: {
-                type: string;
-                id: number;
-            };
-            sNemesisAbility: {
-                type: string;
-                id: number;
-            };
-            cNemesisPickupItem: {
-                type: string;
-                id: number;
-            };
-            sNemesisPickupItem: {
-                type: string;
-                id: number;
-            };
-            cChat: {
-                type: string;
-                id: number;
-            };
-            sChat: {
-                type: string;
-                id: number;
-            };
-            cPlayerDeath: {
-                type: string;
-                id: number;
-            };
-            sPlayerDeath: {
-                type: string;
-                id: number;
-            };
-            cPlayerNewGamePlus: {
-                type: string;
-                id: number;
-            };
-            sPlayerNewGamePlus: {
-                type: string;
-                id: number;
-            };
-            cPlayerSecretHourglass: {
-                type: string;
-                id: number;
-            };
-            sPlayerSecretHourglass: {
-                type: string;
-                id: number;
-            };
-            cCustomModEvent: {
-                type: string;
-                id: number;
-            };
-            sCustomModEvent: {
-                type: string;
-                id: number;
-            };
-            cRespawnPenalty: {
-                type: string;
-                id: number;
-            };
-            sRespawnPenalty: {
-                type: string;
-                id: number;
-            };
-            cAngerySteve: {
-                type: string;
-                id: number;
-            };
-            sAngerySteve: {
-                type: string;
-                id: number;
-            };
-            sStatUpdate: {
-                type: string;
-                id: number;
-            };
-        };
+        cPlayerMove: number;
+        sPlayerMoves: number;
+        cPlayerUpdate: number;
+        sPlayerUpdate: number;
+        cPlayerUpdateInventory: number;
+        sPlayerUpdateInventory: number;
+        cHostItemBank: number;
+        sHostItemBank: number;
+        cHostUserTake: number;
+        sHostUserTake: number;
+        cHostUserTakeGold: number;
+        sHostUserTakeGold: number;
+        cPlayerAddGold: number;
+        sPlayerAddGold: number;
+        cPlayerTakeGold: number;
+        sPlayerTakeGold: number;
+        cPlayerAddItem: number;
+        sPlayerAddItem: number;
+        cPlayerTakeItem: number;
+        sPlayerTakeItem: number;
+        cPlayerPickup: number;
+        sPlayerPickup: number;
+        cNemesisAbility: number;
+        sNemesisAbility: number;
+        cNemesisPickupItem: number;
+        sNemesisPickupItem: number;
+        cChat: number;
+        sChat: number;
+        cPlayerDeath: number;
+        sPlayerDeath: number;
+        cPlayerNewGamePlus: number;
+        sPlayerNewGamePlus: number;
+        cPlayerSecretHourglass: number;
+        sPlayerSecretHourglass: number;
+        cCustomModEvent: number;
+        sCustomModEvent: number;
+        cRespawnPenalty: number;
+        sRespawnPenalty: number;
+        cAngerySteve: number;
+        sAngerySteve: number;
+        sStatUpdate: number;
     };
     PlayerFrame: {
-        oneofs: {
-            _x: {
-                oneof: string[];
-            };
-            _y: {
-                oneof: string[];
-            };
-            _armR: {
-                oneof: string[];
-            };
-            _armScaleY: {
-                oneof: string[];
-            };
-            _scaleX: {
-                oneof: string[];
-            };
-            _anim: {
-                oneof: string[];
-            };
-            _held: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            x: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            y: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            armR: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            armScaleY: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            scaleX: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            anim: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            held: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
+        x: number;
+        y: number;
+        armR: number;
+        armScaleY: number;
+        scaleX: number;
+        anim: number;
+        held: number;
     };
     OldClientPlayerMove: {
-        fields: {
-            frames: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
+        frames: number;
     };
     OldServerPlayerMove: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            frames: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        frames: number;
     };
     CompactPlayerFrames: {
-        fields: {
-            xInit: {
-                type: string;
-                id: number;
-            };
-            yInit: {
-                type: string;
-                id: number;
-            };
-            xDeltas: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            yDeltas: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            armR: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            armScaleY: {
-                type: string;
-                id: number;
-            };
-            scaleX: {
-                type: string;
-                id: number;
-            };
-            animIdx: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            animVal: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            heldIdx: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            heldVal: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
+        xInit: number;
+        yInit: number;
+        xDeltas: number;
+        yDeltas: number;
+        armR: number;
+        armScaleY: number;
+        scaleX: number;
+        animIdx: number;
+        animVal: number;
+        heldIdx: number;
+        heldVal: number;
+        userId: number;
     };
     ServerPlayerMoves: {
-        fields: {
-            userFrames: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
+        userFrames: number;
     };
     ClientPlayerUpdate: {
-        oneofs: {
-            _curHp: {
-                oneof: string[];
-            };
-            _maxHp: {
-                oneof: string[];
-            };
-            _location: {
-                oneof: string[];
-            };
-            _sampo: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            curHp: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            maxHp: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            location: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            sampo: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
+        curHp: number;
+        maxHp: number;
+        location: number;
+        sampo: number;
     };
     ServerPlayerUpdate: {
-        oneofs: {
-            _curHp: {
-                oneof: string[];
-            };
-            _maxHp: {
-                oneof: string[];
-            };
-            _location: {
-                oneof: string[];
-            };
-            _sampo: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            curHp: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            maxHp: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            location: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            sampo: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
+        userId: number;
+        curHp: number;
+        maxHp: number;
+        location: number;
+        sampo: number;
     };
     ClientPlayerUpdateInventory: {
-        fields: {
-            wands: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            items: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            spells: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            InventoryWand: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    wand: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            InventoryItem: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    item: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            InventorySpell: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    spell: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
+        wands: number;
+        items: number;
+        spells: number;
     };
     ServerPlayerUpdateInventory: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            wands: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            items: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            spells: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            InventoryWand: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    wand: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            InventoryItem: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    item: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            InventorySpell: {
-                fields: {
-                    index: {
-                        type: string;
-                        id: number;
-                    };
-                    spell: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
+        userId: number;
+        wands: number;
+        items: number;
+        spells: number;
     };
     ClientHostItemBank: {
-        fields: {
-            wands: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            spells: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            items: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            gold: {
-                type: string;
-                id: number;
-            };
-            objects: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
+        wands: number;
+        spells: number;
+        items: number;
+        gold: number;
+        objects: number;
     };
     ServerHostItemBank: {
-        fields: {
-            wands: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            spells: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            items: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            gold: {
-                type: string;
-                id: number;
-            };
-            objects: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
+        wands: number;
+        spells: number;
+        items: number;
+        gold: number;
+        objects: number;
     };
     ClientHostUserTake: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            id: {
-                type: string;
-                id: number;
-            };
-            success: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        id: number;
+        success: number;
     };
     ServerHostUserTake: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            id: {
-                type: string;
-                id: number;
-            };
-            success: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        id: number;
+        success: number;
     };
     ClientHostUserTakeGold: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            amount: {
-                type: string;
-                id: number;
-            };
-            success: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        amount: number;
+        success: number;
     };
     ServerHostUserTakeGold: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            amount: {
-                type: string;
-                id: number;
-            };
-            success: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        amount: number;
+        success: number;
     };
     ClientPlayerAddGold: {
-        fields: {
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
+        amount: number;
     };
     ServerPlayerAddGold: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        amount: number;
     };
     ClientPlayerTakeGold: {
-        fields: {
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
+        amount: number;
     };
     ServerPlayerTakeGold: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
+        userId: number;
+        amount: number;
     };
     ClientPlayerAddItem: {
-        oneofs: {
-            item: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            spells: {
-                type: string;
-                id: number;
-            };
-            wands: {
-                type: string;
-                id: number;
-            };
-            flasks: {
-                type: string;
-                id: number;
-            };
-            objects: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            Spells: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Wands: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Items: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Entities: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
+        spells: number;
+        wands: number;
+        flasks: number;
+        objects: number;
     };
     ServerPlayerAddItem: {
-        oneofs: {
-            item: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            spells: {
-                type: string;
-                id: number;
-            };
-            wands: {
-                type: string;
-                id: number;
-            };
-            flasks: {
-                type: string;
-                id: number;
-            };
-            objects: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            Spells: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Wands: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Items: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Entities: {
-                fields: {
-                    list: {
-                        rule: string;
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
+        userId: number;
+        spells: number;
+        wands: number;
+        flasks: number;
+        objects: number;
     };
     ClientPlayerTakeItem: {
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerPlayerTakeItem: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            id: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientChat: {
-        fields: {
-            message: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerChat: {
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            userId: {
-                type: string;
-                id: number;
-            };
-            name: {
-                type: string;
-                id: number;
-            };
-            message: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerStatsUpdate: {
-        fields: {
-            data: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientPlayerPickup: {
-        oneofs: {
-            kind: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            heart: {
-                type: string;
-                id: number;
-            };
-            orb: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            HeartPickup: {
-                fields: {
-                    hpPerk: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            OrbPickup: {
-                fields: {
-                    id: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    ServerPlayerPickup: {
-        oneofs: {
-            kind: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            heart: {
-                type: string;
-                id: number;
-            };
-            orb: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            HeartPickup: {
-                fields: {
-                    hpPerk: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            OrbPickup: {
-                fields: {
-                    id: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    ClientNemesisPickupItem: {
-        fields: {
-            gameId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerNemesisPickupItem: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            gameId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientNemesisAbility: {
-        fields: {
-            gameId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerNemesisAbility: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            gameId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientPlayerDeath: {
-        oneofs: {
-            _gameTime: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            isWin: {
-                type: string;
-                id: number;
-            };
-            gameTime: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerPlayerDeath: {
-        oneofs: {
-            _gameTime: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            isWin: {
-                type: string;
-                id: number;
-            };
-            gameTime: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ClientPlayerNewGamePlus: {
-        fields: {
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerPlayerNewGamePlus: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            amount: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientPlayerSecretHourglass: {
-        fields: {
-            material: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerPlayerSecretHourglass: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            material: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientCustomModEvent: {
-        fields: {
-            payload: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerCustomModEvent: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            payload: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRespawnPenalty: {
-        fields: {
-            deaths: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerRespawnPenalty: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            deaths: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientAngerySteve: {
-        fields: {
-            idk: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerAngerySteve: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    Wand: {
-        oneofs: {
-            _sentBy: {
-                oneof: string[];
-            };
-            _contributedBy: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            stats: {
-                type: string;
-                id: number;
-            };
-            alwaysCast: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            deck: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            sentBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            contributedBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-        nested: {
-            WandStats: {
-                fields: {
-                    sprite: {
-                        type: string;
-                        id: number;
-                    };
-                    named: {
-                        type: string;
-                        id: number;
-                    };
-                    uiName: {
-                        type: string;
-                        id: number;
-                    };
-                    manaMax: {
-                        type: string;
-                        id: number;
-                    };
-                    manaChargeSpeed: {
-                        type: string;
-                        id: number;
-                    };
-                    reloadTime: {
-                        type: string;
-                        id: number;
-                    };
-                    actionsPerRound: {
-                        type: string;
-                        id: number;
-                    };
-                    deckCapacity: {
-                        type: string;
-                        id: number;
-                    };
-                    shuffleDeckWhenEmpty: {
-                        type: string;
-                        id: number;
-                    };
-                    spreadDegrees: {
-                        type: string;
-                        id: number;
-                    };
-                    speedMultiplier: {
-                        type: string;
-                        id: number;
-                    };
-                    fireRateWait: {
-                        type: string;
-                        id: number;
-                    };
-                    tipX: {
-                        type: string;
-                        id: number;
-                    };
-                    tipY: {
-                        type: string;
-                        id: number;
-                    };
-                    gripX: {
-                        type: string;
-                        id: number;
-                    };
-                    gripY: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    Spell: {
-        oneofs: {
-            _sentBy: {
-                oneof: string[];
-            };
-            _contributedBy: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            gameId: {
-                type: string;
-                id: number;
-            };
-            sentBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            contributedBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            usesRemaining: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    Item: {
-        oneofs: {
-            _sentBy: {
-                oneof: string[];
-            };
-            _contributedBy: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            color: {
-                type: string;
-                id: number;
-            };
-            content: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            sentBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            contributedBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            isChest: {
-                type: string;
-                id: number;
-                options: {
-                    deprecated: boolean;
-                };
-            };
-            itemType: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            Color: {
-                fields: {
-                    r: {
-                        type: string;
-                        id: number;
-                    };
-                    g: {
-                        type: string;
-                        id: number;
-                    };
-                    b: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-            Material: {
-                fields: {
-                    id: {
-                        type: string;
-                        id: number;
-                    };
-                    amount: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    EntityItem: {
-        oneofs: {
-            _sentBy: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            path: {
-                type: string;
-                id: number;
-            };
-            sprite: {
-                type: string;
-                id: number;
-            };
-            sentBy: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    LobbyAction: {
-        oneofs: {
-            action: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            cRoomCreate: {
-                type: string;
-                id: number;
-            };
-            sRoomCreated: {
-                type: string;
-                id: number;
-            };
-            sRoomCreateFailed: {
-                type: string;
-                id: number;
-            };
-            cRoomUpdate: {
-                type: string;
-                id: number;
-            };
-            sRoomUpdated: {
-                type: string;
-                id: number;
-            };
-            sRoomUpdateFailed: {
-                type: string;
-                id: number;
-            };
-            cRoomFlagsUpdate: {
-                type: string;
-                id: number;
-            };
-            sRoomFlagsUpdated: {
-                type: string;
-                id: number;
-            };
-            sRoomFlagsUpdateFailed: {
-                type: string;
-                id: number;
-            };
-            cRoomDelete: {
-                type: string;
-                id: number;
-            };
-            sRoomDeleted: {
-                type: string;
-                id: number;
-            };
-            cJoinRoom: {
-                type: string;
-                id: number;
-            };
-            sJoinRoomSuccess: {
-                type: string;
-                id: number;
-            };
-            sJoinRoomFailed: {
-                type: string;
-                id: number;
-            };
-            sUserJoinedRoom: {
-                type: string;
-                id: number;
-            };
-            cLeaveRoom: {
-                type: string;
-                id: number;
-            };
-            sUserLeftRoom: {
-                type: string;
-                id: number;
-            };
-            cKickUser: {
-                type: string;
-                id: number;
-            };
-            sUserKicked: {
-                type: string;
-                id: number;
-            };
-            cBanUser: {
-                type: string;
-                id: number;
-            };
-            sUserBanned: {
-                type: string;
-                id: number;
-            };
-            cReadyState: {
-                type: string;
-                id: number;
-            };
-            sUserReadyState: {
-                type: string;
-                id: number;
-            };
-            cStartRun: {
-                type: string;
-                id: number;
-            };
-            sHostStart: {
-                type: string;
-                id: number;
-            };
-            cRequestRoomList: {
-                type: string;
-                id: number;
-            };
-            sRoomList: {
-                type: string;
-                id: number;
-            };
-            sDisconnected: {
-                type: string;
-                id: number;
-            };
-            sRoomAddToList: {
-                type: string;
-                id: number;
-            };
-            cRunOver: {
-                type: string;
-                id: number;
-            };
-            cRoomModFlagsUpdate: {
-                type: string;
-                id: number;
-            };
-            sRoomModFlagsUpdated: {
-                type: string;
-                id: number;
-            };
-            sRoomModFlagsUpdateFailed: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRunOver: {
-        oneofs: {
-            _idk: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            idk: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerDisconnected: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRoomDelete: {
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerRoomDeleted: {
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRoomCreate: {
-        oneofs: {
-            _password: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            name: {
-                type: string;
-                id: number;
-            };
-            gamemode: {
-                type: string;
-                id: number;
-            };
-            maxUsers: {
-                type: string;
-                id: number;
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerRoomCreated: {
-        oneofs: {
-            _password: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            name: {
-                type: string;
-                id: number;
-            };
-            gamemode: {
-                type: string;
-                id: number;
-            };
-            maxUsers: {
-                type: string;
-                id: number;
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            locked: {
-                type: string;
-                id: number;
-            };
-            users: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            User: {
-                fields: {
-                    userId: {
-                        type: string;
-                        id: number;
-                    };
-                    name: {
-                        type: string;
-                        id: number;
-                    };
-                    ready: {
-                        type: string;
-                        id: number;
-                    };
-                    owner: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    ServerRoomCreateFailed: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRoomUpdate: {
-        oneofs: {
-            _name: {
-                oneof: string[];
-            };
-            _gamemode: {
-                oneof: string[];
-            };
-            _maxUsers: {
-                oneof: string[];
-            };
-            _password: {
-                oneof: string[];
-            };
-            _locked: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            name: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            gamemode: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            maxUsers: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            locked: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerRoomUpdated: {
-        oneofs: {
-            _name: {
-                oneof: string[];
-            };
-            _gamemode: {
-                oneof: string[];
-            };
-            _maxUsers: {
-                oneof: string[];
-            };
-            _password: {
-                oneof: string[];
-            };
-            _locked: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            name: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            gamemode: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            maxUsers: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            locked: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerRoomUpdateFailed: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRoomFlagsUpdate: {
-        fields: {
-            flags: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            GameFlag: {
-                oneofs: {
-                    _intVal: {
-                        oneof: string[];
-                    };
-                    _strVal: {
-                        oneof: string[];
-                    };
-                    _floatVal: {
-                        oneof: string[];
-                    };
-                    _boolVal: {
-                        oneof: string[];
-                    };
-                    _uIntVal: {
-                        oneof: string[];
-                    };
-                };
-                fields: {
-                    flag: {
-                        type: string;
-                        id: number;
-                    };
-                    intVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    strVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    floatVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    boolVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    uIntVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    ServerRoomFlagsUpdated: {
-        fields: {
-            flags: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            GameFlag: {
-                oneofs: {
-                    _intVal: {
-                        oneof: string[];
-                    };
-                    _strVal: {
-                        oneof: string[];
-                    };
-                    _floatVal: {
-                        oneof: string[];
-                    };
-                    _boolVal: {
-                        oneof: string[];
-                    };
-                    _uIntVal: {
-                        oneof: string[];
-                    };
-                };
-                fields: {
-                    flag: {
-                        type: string;
-                        id: number;
-                    };
-                    intVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    strVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    floatVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    boolVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                    uIntVal: {
-                        type: string;
-                        id: number;
-                        options: {
-                            proto3_optional: boolean;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    ServerRoomFlagsUpdateFailed: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientModFlagsUpdate: {
-        fields: {
-            modFlags: {
-                keyType: string;
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerModFlagsUpdated: {
-        fields: {
-            modFlags: {
-                keyType: string;
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerModFlagsUpdateFailed: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientJoinRoom: {
-        oneofs: {
-            _password: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerJoinRoomSuccess: {
-        oneofs: {
-            _password: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            id: {
-                type: string;
-                id: number;
-            };
-            name: {
-                type: string;
-                id: number;
-            };
-            gamemode: {
-                type: string;
-                id: number;
-            };
-            maxUsers: {
-                type: string;
-                id: number;
-            };
-            password: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            locked: {
-                type: string;
-                id: number;
-            };
-            users: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            User: {
-                fields: {
-                    userId: {
-                        type: string;
-                        id: number;
-                    };
-                    name: {
-                        type: string;
-                        id: number;
-                    };
-                    ready: {
-                        type: string;
-                        id: number;
-                    };
-                    owner: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    ServerJoinRoomFailed: {
-        fields: {
-            reason: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerUserJoinedRoom: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            name: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientLeaveRoom: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerUserLeftRoom: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientKickUser: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerUserKicked: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientBanUser: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerUserBanned: {
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientReadyState: {
-        oneofs: {
-            _seed: {
-                oneof: string[];
-            };
-            _version: {
-                oneof: string[];
-            };
-            _beta: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            ready: {
-                type: string;
-                id: number;
-            };
-            seed: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            mods: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            version: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            beta: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ServerUserReadyState: {
-        oneofs: {
-            _seed: {
-                oneof: string[];
-            };
-            _version: {
-                oneof: string[];
-            };
-            _beta: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            userId: {
-                type: string;
-                id: number;
-            };
-            ready: {
-                type: string;
-                id: number;
-            };
-            seed: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            mods: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            version: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-            beta: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-    };
-    ClientStartRun: {
-        fields: {
-            forced: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerHostStart: {
-        fields: {
-            forced: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ClientRequestRoomList: {
-        fields: {
-            page: {
-                type: string;
-                id: number;
-            };
-        };
-    };
-    ServerRoomList: {
-        oneofs: {
-            _pages: {
-                oneof: string[];
-            };
-        };
-        fields: {
-            rooms: {
-                rule: string;
-                type: string;
-                id: number;
-            };
-            pages: {
-                type: string;
-                id: number;
-                options: {
-                    proto3_optional: boolean;
-                };
-            };
-        };
-        nested: {
-            Room: {
-                fields: {
-                    id: {
-                        type: string;
-                        id: number;
-                    };
-                    name: {
-                        type: string;
-                        id: number;
-                    };
-                    gamemode: {
-                        type: string;
-                        id: number;
-                    };
-                    curUsers: {
-                        type: string;
-                        id: number;
-                    };
-                    maxUsers: {
-                        type: string;
-                        id: number;
-                    };
-                    protected: {
-                        type: string;
-                        id: number;
-                    };
-                    owner: {
-                        type: string;
-                        id: number;
-                    };
-                    locked: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-    ServerRoomAddToList: {
-        fields: {
-            room: {
-                type: string;
-                id: number;
-            };
-        };
-        nested: {
-            Room: {
-                fields: {
-                    id: {
-                        type: string;
-                        id: number;
-                    };
-                    name: {
-                        type: string;
-                        id: number;
-                    };
-                    gamemode: {
-                        type: string;
-                        id: number;
-                    };
-                    curUsers: {
-                        type: string;
-                        id: number;
-                    };
-                    maxUsers: {
-                        type: string;
-                        id: number;
-                    };
-                    protected: {
-                        type: string;
-                        id: number;
-                    };
-                    owner: {
-                        type: string;
-                        id: number;
-                    };
-                    locked: {
-                        type: string;
-                        id: number;
-                    };
-                };
-            };
-        };
-    };
-};
-type FieldList = {
-    [key: string]: {
-        type: string;
         id: number;
     };
-};
-type FieldIds<T extends FieldList> = {
-    [K in keyof T]: T[K]['id'];
-} & unknown;
-type MessageIds<T extends {
-    [key in keyof T]: {
-        fields: FieldList;
+    ServerPlayerTakeItem: {
+        userId: number;
+        id: number;
     };
-}> = {
-    [K in keyof T]: FieldIds<T[K]['fields']>;
-} & unknown;
-export declare const Messages: MessageIds<typeof NT>;
+    ClientChat: {
+        message: number;
+    };
+    ServerChat: {
+        id: number;
+        userId: number;
+        name: number;
+        message: number;
+    };
+    ServerStatsUpdate: {
+        data: number;
+    };
+    ClientPlayerPickup: {
+        heart: number;
+        orb: number;
+    };
+    ServerPlayerPickup: {
+        userId: number;
+        heart: number;
+        orb: number;
+    };
+    ClientNemesisPickupItem: {
+        gameId: number;
+    };
+    ServerNemesisPickupItem: {
+        userId: number;
+        gameId: number;
+    };
+    ClientNemesisAbility: {
+        gameId: number;
+    };
+    ServerNemesisAbility: {
+        userId: number;
+        gameId: number;
+    };
+    ClientPlayerDeath: {
+        isWin: number;
+        gameTime: number;
+    };
+    ServerPlayerDeath: {
+        userId: number;
+        isWin: number;
+        gameTime: number;
+    };
+    ClientPlayerNewGamePlus: {
+        amount: number;
+    };
+    ServerPlayerNewGamePlus: {
+        userId: number;
+        amount: number;
+    };
+    ClientPlayerSecretHourglass: {
+        material: number;
+    };
+    ServerPlayerSecretHourglass: {
+        userId: number;
+        material: number;
+    };
+    ClientCustomModEvent: {
+        payload: number;
+    };
+    ServerCustomModEvent: {
+        userId: number;
+        payload: number;
+    };
+    ClientRespawnPenalty: {
+        deaths: number;
+    };
+    ServerRespawnPenalty: {
+        userId: number;
+        deaths: number;
+    };
+    ClientAngerySteve: {
+        idk: number;
+    };
+    ServerAngerySteve: {
+        userId: number;
+    };
+    Wand: {
+        id: number;
+        stats: number;
+        alwaysCast: number;
+        deck: number;
+        sentBy: number;
+        contributedBy: number;
+    };
+    Spell: {
+        id: number;
+        gameId: number;
+        sentBy: number;
+        contributedBy: number;
+        usesRemaining: number;
+    };
+    Item: {
+        id: number;
+        color: number;
+        content: number;
+        sentBy: number;
+        contributedBy: number;
+        isChest: number;
+        itemType: number;
+    };
+    EntityItem: {
+        id: number;
+        path: number;
+        sprite: number;
+        sentBy: number;
+    };
+    LobbyAction: {
+        cRoomCreate: number;
+        sRoomCreated: number;
+        sRoomCreateFailed: number;
+        cRoomUpdate: number;
+        sRoomUpdated: number;
+        sRoomUpdateFailed: number;
+        cRoomFlagsUpdate: number;
+        sRoomFlagsUpdated: number;
+        sRoomFlagsUpdateFailed: number;
+        cRoomDelete: number;
+        sRoomDeleted: number;
+        cJoinRoom: number;
+        sJoinRoomSuccess: number;
+        sJoinRoomFailed: number;
+        sUserJoinedRoom: number;
+        cLeaveRoom: number;
+        sUserLeftRoom: number;
+        cKickUser: number;
+        sUserKicked: number;
+        cBanUser: number;
+        sUserBanned: number;
+        cReadyState: number;
+        sUserReadyState: number;
+        cStartRun: number;
+        sHostStart: number;
+        cRequestRoomList: number;
+        sRoomList: number;
+        sDisconnected: number;
+        sRoomAddToList: number;
+        cRunOver: number;
+        cRoomModFlagsUpdate: number;
+        sRoomModFlagsUpdated: number;
+        sRoomModFlagsUpdateFailed: number;
+    };
+    ClientRunOver: {
+        idk: number;
+    };
+    ServerDisconnected: {
+        reason: number;
+    };
+    ClientRoomDelete: {
+        id: number;
+    };
+    ServerRoomDeleted: {
+        id: number;
+    };
+    ClientRoomCreate: {
+        name: number;
+        gamemode: number;
+        maxUsers: number;
+        password: number;
+    };
+    ServerRoomCreated: {
+        id: number;
+        name: number;
+        gamemode: number;
+        maxUsers: number;
+        password: number;
+        locked: number;
+        users: number;
+    };
+    ServerRoomCreateFailed: {
+        reason: number;
+    };
+    ClientRoomUpdate: {
+        name: number;
+        gamemode: number;
+        maxUsers: number;
+        password: number;
+        locked: number;
+    };
+    ServerRoomUpdated: {
+        name: number;
+        gamemode: number;
+        maxUsers: number;
+        password: number;
+        locked: number;
+    };
+    ServerRoomUpdateFailed: {
+        reason: number;
+    };
+    ClientRoomFlagsUpdate: {
+        flags: number;
+    };
+    ServerRoomFlagsUpdated: {
+        flags: number;
+    };
+    ServerRoomFlagsUpdateFailed: {
+        reason: number;
+    };
+    ModFlagsListType: {
+        UNSPECIFIED: number;
+        ALLOWED: number;
+        DENIED: number;
+    };
+    ClientModFlagsUpdate: {
+        modFlags: number;
+    };
+    ServerModFlagsUpdated: {
+        modFlags: number;
+    };
+    ServerModFlagsUpdateFailed: {
+        reason: number;
+    };
+    ClientJoinRoom: {
+        id: number;
+        password: number;
+    };
+    ServerJoinRoomSuccess: {
+        id: number;
+        name: number;
+        gamemode: number;
+        maxUsers: number;
+        password: number;
+        locked: number;
+        users: number;
+    };
+    ServerJoinRoomFailed: {
+        reason: number;
+    };
+    ServerUserJoinedRoom: {
+        userId: number;
+        name: number;
+    };
+    ClientLeaveRoom: {
+        userId: number;
+    };
+    ServerUserLeftRoom: {
+        userId: number;
+    };
+    ClientKickUser: {
+        userId: number;
+    };
+    ServerUserKicked: {
+        userId: number;
+    };
+    ClientBanUser: {
+        userId: number;
+    };
+    ServerUserBanned: {
+        userId: number;
+    };
+    ClientReadyState: {
+        ready: number;
+        seed: number;
+        mods: number;
+        version: number;
+        beta: number;
+    };
+    ServerUserReadyState: {
+        userId: number;
+        ready: number;
+        seed: number;
+        mods: number;
+        version: number;
+        beta: number;
+    };
+    ClientStartRun: {
+        forced: number;
+    };
+    ServerHostStart: {
+        forced: number;
+    };
+    ClientRequestRoomList: {
+        page: number;
+    };
+    ServerRoomList: {
+        rooms: number;
+        pages: number;
+    };
+    ServerRoomAddToList: {
+        room: number;
+    };
+};
 export declare const gameActions: ("cPlayerMove" | "sPlayerMoves" | "cPlayerUpdate" | "sPlayerUpdate" | "cPlayerUpdateInventory" | "sPlayerUpdateInventory" | "cHostItemBank" | "sHostItemBank" | "cHostUserTake" | "sHostUserTake" | "cHostUserTakeGold" | "sHostUserTakeGold" | "cPlayerAddGold" | "sPlayerAddGold" | "cPlayerTakeGold" | "sPlayerTakeGold" | "cPlayerAddItem" | "sPlayerAddItem" | "cPlayerTakeItem" | "sPlayerTakeItem" | "cPlayerPickup" | "sPlayerPickup" | "cNemesisAbility" | "sNemesisAbility" | "cNemesisPickupItem" | "sNemesisPickupItem" | "cChat" | "sChat" | "cPlayerDeath" | "sPlayerDeath" | "cPlayerNewGamePlus" | "sPlayerNewGamePlus" | "cPlayerSecretHourglass" | "sPlayerSecretHourglass" | "cCustomModEvent" | "sCustomModEvent" | "cRespawnPenalty" | "sRespawnPenalty" | "cAngerySteve" | "sAngerySteve" | "sStatUpdate")[];
 export declare const lobbyActions: ("cRoomCreate" | "sRoomCreated" | "sRoomCreateFailed" | "cRoomUpdate" | "sRoomUpdated" | "sRoomUpdateFailed" | "cRoomFlagsUpdate" | "sRoomFlagsUpdated" | "sRoomFlagsUpdateFailed" | "cRoomDelete" | "sRoomDeleted" | "cJoinRoom" | "sJoinRoomSuccess" | "sJoinRoomFailed" | "sUserJoinedRoom" | "cLeaveRoom" | "sUserLeftRoom" | "cKickUser" | "sUserKicked" | "cBanUser" | "sUserBanned" | "cReadyState" | "sUserReadyState" | "cStartRun" | "sHostStart" | "cRequestRoomList" | "sRoomList" | "sDisconnected" | "sRoomAddToList" | "cRunOver" | "cRoomModFlagsUpdate" | "sRoomModFlagsUpdated" | "sRoomModFlagsUpdateFailed")[];
-export {};

--- a/dist/pbreflect.js
+++ b/dist/pbreflect.js
@@ -6,15 +6,23 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.lobbyActions = exports.gameActions = exports.Messages = void 0;
 const pbjs_pb_json_1 = __importDefault(require("./pbjs_pb.json"));
 const NT = pbjs_pb_json_1.default.nested.NT.nested;
-exports.Messages = Object.create(null);
+const MessagesImpl = Object.create(null);
 for (const [msgName, defs] of Object.entries(NT)) {
-    if (!defs.fields)
-        continue;
-    const fields = Object.create(null);
-    for (const [fieldName, nameid] of Object.entries(defs.fields)) {
-        fields[fieldName] = nameid.id;
+    if ('fields' in defs) {
+        const fields = Object.create(null);
+        for (const [fieldName, nameid] of Object.entries(defs.fields)) {
+            fields[fieldName] = nameid.id;
+        }
+        MessagesImpl[msgName] = fields;
     }
-    exports.Messages[msgName] = fields;
+    else if ('values' in defs) {
+        const values = Object.create(null);
+        for (const [valueName, valueId] of Object.entries(defs.values)) {
+            values[valueName] = valueId;
+        }
+        MessagesImpl[msgName] = values;
+    }
 }
+exports.Messages = MessagesImpl;
 exports.gameActions = Object.keys(pbjs_pb_json_1.default.nested.NT.nested.GameAction.fields);
 exports.lobbyActions = Object.keys(pbjs_pb_json_1.default.nested.NT.nested.LobbyAction.fields);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noita-together/nt-message",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noita-together/nt-message",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "long": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build_proto": "pbjs -w commonjs -t static-module ./proto/messages.proto > ./src/pbjs_pb.js && pbts ./src/pbjs_pb.js > ./src/pbjs_pb.d.ts && pbjs -t json ./proto/messages.proto > ./src/pbjs_pb.json",
     "test": "npm run build_proto && tsc --noEmit && npx jest",
-    "build": "npm run test && rm -rf dist/* && npx tsc && cp src/pbjs_pb.* dist"
+    "build": "npm run test && rm -rf dist/* && npx tsc && cp src/pbjs_pb.* dist",
+    "build_windows": "npm run test && if exist dist del /F /Q dist\\* && npx tsc && copy src\\pbjs_pb.* dist"
   },
   "author": "Kris Reeves",
   "license": "MIT",

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -611,12 +611,18 @@ message ServerRoomFlagsUpdateFailed {
     string reason = 1;
 }
 
+enum ModFlagsListType {
+    UNSPECIFIED = 0;
+    ALLOWED = 1;
+    DENIED = 2;
+}
+
 message ClientModFlagsUpdate {
-    map<string, string> modFlags = 1;
+    map<string, ModFlagsListType> modFlags = 1;
 }
 
 message ServerModFlagsUpdated {
-    map<string, string> modFlags = 1;
+    map<string, ModFlagsListType> modFlags = 1;
 }
 
 message ServerModFlagsUpdateFailed {

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -511,6 +511,10 @@ message LobbyAction {
         ServerRoomAddToList s_room_add_to_list = 32;
 
         ClientRunOver c_run_over = 33;
+
+        ClientModFlagsUpdate c_room_mod_flags_update = 34;
+        ServerModFlagsUpdated s_room_mod_flags_updated = 35;
+        ServerModFlagsUpdateFailed s_room_mod_flags_update_failed = 36;
     }
 }
 
@@ -604,6 +608,18 @@ message ServerRoomFlagsUpdated {
 }
 
 message ServerRoomFlagsUpdateFailed {
+    string reason = 1;
+}
+
+message ClientModFlagsUpdate {
+    map<string, string> modFlags = 1;
+}
+
+message ServerModFlagsUpdated {
+    map<string, string> modFlags = 1;
+}
+
+message ServerModFlagsUpdateFailed {
     string reason = 1;
 }
 

--- a/src/pbjs_pb.d.ts
+++ b/src/pbjs_pb.d.ts
@@ -8020,6 +8020,15 @@ export namespace NT {
 
         /** LobbyAction cRunOver */
         cRunOver?: (NT.IClientRunOver|null);
+
+        /** LobbyAction cRoomModFlagsUpdate */
+        cRoomModFlagsUpdate?: (NT.IClientModFlagsUpdate|null);
+
+        /** LobbyAction sRoomModFlagsUpdated */
+        sRoomModFlagsUpdated?: (NT.IServerModFlagsUpdated|null);
+
+        /** LobbyAction sRoomModFlagsUpdateFailed */
+        sRoomModFlagsUpdateFailed?: (NT.IServerModFlagsUpdateFailed|null);
     }
 
     /** Represents a LobbyAction. */
@@ -8121,8 +8130,17 @@ export namespace NT {
         /** LobbyAction cRunOver. */
         public cRunOver?: (NT.IClientRunOver|null);
 
+        /** LobbyAction cRoomModFlagsUpdate. */
+        public cRoomModFlagsUpdate?: (NT.IClientModFlagsUpdate|null);
+
+        /** LobbyAction sRoomModFlagsUpdated. */
+        public sRoomModFlagsUpdated?: (NT.IServerModFlagsUpdated|null);
+
+        /** LobbyAction sRoomModFlagsUpdateFailed. */
+        public sRoomModFlagsUpdateFailed?: (NT.IServerModFlagsUpdateFailed|null);
+
         /** LobbyAction action. */
-        public action?: ("cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver");
+        public action?: ("cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|"cRoomModFlagsUpdate"|"sRoomModFlagsUpdated"|"sRoomModFlagsUpdateFailed");
 
         /**
          * Creates a new LobbyAction instance using the specified properties.
@@ -10006,6 +10024,297 @@ export namespace NT {
 
         /**
          * Gets the default type url for ServerRoomFlagsUpdateFailed
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ClientModFlagsUpdate. */
+    interface IClientModFlagsUpdate {
+
+        /** ClientModFlagsUpdate modFlags */
+        modFlags?: ({ [k: string]: string }|null);
+    }
+
+    /** Represents a ClientModFlagsUpdate. */
+    class ClientModFlagsUpdate implements IClientModFlagsUpdate {
+
+        /**
+         * Constructs a new ClientModFlagsUpdate.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IClientModFlagsUpdate);
+
+        /** ClientModFlagsUpdate modFlags. */
+        public modFlags: { [k: string]: string };
+
+        /**
+         * Creates a new ClientModFlagsUpdate instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ClientModFlagsUpdate instance
+         */
+        public static create(properties?: NT.IClientModFlagsUpdate): NT.ClientModFlagsUpdate;
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @param message ClientModFlagsUpdate message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IClientModFlagsUpdate, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message, length delimited. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @param message ClientModFlagsUpdate message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IClientModFlagsUpdate, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ClientModFlagsUpdate;
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ClientModFlagsUpdate;
+
+        /**
+         * Verifies a ClientModFlagsUpdate message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ClientModFlagsUpdate message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ClientModFlagsUpdate
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ClientModFlagsUpdate;
+
+        /**
+         * Creates a plain object from a ClientModFlagsUpdate message. Also converts values to other types if specified.
+         * @param message ClientModFlagsUpdate
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ClientModFlagsUpdate, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ClientModFlagsUpdate to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ClientModFlagsUpdate
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ServerModFlagsUpdated. */
+    interface IServerModFlagsUpdated {
+
+        /** ServerModFlagsUpdated modFlags */
+        modFlags?: ({ [k: string]: string }|null);
+    }
+
+    /** Represents a ServerModFlagsUpdated. */
+    class ServerModFlagsUpdated implements IServerModFlagsUpdated {
+
+        /**
+         * Constructs a new ServerModFlagsUpdated.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IServerModFlagsUpdated);
+
+        /** ServerModFlagsUpdated modFlags. */
+        public modFlags: { [k: string]: string };
+
+        /**
+         * Creates a new ServerModFlagsUpdated instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ServerModFlagsUpdated instance
+         */
+        public static create(properties?: NT.IServerModFlagsUpdated): NT.ServerModFlagsUpdated;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @param message ServerModFlagsUpdated message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IServerModFlagsUpdated, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @param message ServerModFlagsUpdated message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IServerModFlagsUpdated, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ServerModFlagsUpdated;
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ServerModFlagsUpdated;
+
+        /**
+         * Verifies a ServerModFlagsUpdated message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ServerModFlagsUpdated message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ServerModFlagsUpdated
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ServerModFlagsUpdated;
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdated message. Also converts values to other types if specified.
+         * @param message ServerModFlagsUpdated
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ServerModFlagsUpdated, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ServerModFlagsUpdated to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdated
+         * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns The default type url
+         */
+        public static getTypeUrl(typeUrlPrefix?: string): string;
+    }
+
+    /** Properties of a ServerModFlagsUpdateFailed. */
+    interface IServerModFlagsUpdateFailed {
+
+        /** ServerModFlagsUpdateFailed reason */
+        reason?: (string|null);
+    }
+
+    /** Represents a ServerModFlagsUpdateFailed. */
+    class ServerModFlagsUpdateFailed implements IServerModFlagsUpdateFailed {
+
+        /**
+         * Constructs a new ServerModFlagsUpdateFailed.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: NT.IServerModFlagsUpdateFailed);
+
+        /** ServerModFlagsUpdateFailed reason. */
+        public reason: string;
+
+        /**
+         * Creates a new ServerModFlagsUpdateFailed instance using the specified properties.
+         * @param [properties] Properties to set
+         * @returns ServerModFlagsUpdateFailed instance
+         */
+        public static create(properties?: NT.IServerModFlagsUpdateFailed): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @param message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: NT.IServerModFlagsUpdateFailed, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @param message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: NT.IServerModFlagsUpdateFailed, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Verifies a ServerModFlagsUpdateFailed message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a ServerModFlagsUpdateFailed message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns ServerModFlagsUpdateFailed
+         */
+        public static fromObject(object: { [k: string]: any }): NT.ServerModFlagsUpdateFailed;
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdateFailed message. Also converts values to other types if specified.
+         * @param message ServerModFlagsUpdateFailed
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: NT.ServerModFlagsUpdateFailed, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this ServerModFlagsUpdateFailed to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdateFailed
          * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
          * @returns The default type url
          */

--- a/src/pbjs_pb.d.ts
+++ b/src/pbjs_pb.d.ts
@@ -10030,11 +10030,18 @@ export namespace NT {
         public static getTypeUrl(typeUrlPrefix?: string): string;
     }
 
+    /** ModFlagsListType enum. */
+    enum ModFlagsListType {
+        UNSPECIFIED = 0,
+        ALLOWED = 1,
+        DENIED = 2
+    }
+
     /** Properties of a ClientModFlagsUpdate. */
     interface IClientModFlagsUpdate {
 
         /** ClientModFlagsUpdate modFlags */
-        modFlags?: ({ [k: string]: string }|null);
+        modFlags?: ({ [k: string]: NT.ModFlagsListType }|null);
     }
 
     /** Represents a ClientModFlagsUpdate. */
@@ -10047,7 +10054,7 @@ export namespace NT {
         constructor(properties?: NT.IClientModFlagsUpdate);
 
         /** ClientModFlagsUpdate modFlags. */
-        public modFlags: { [k: string]: string };
+        public modFlags: { [k: string]: NT.ModFlagsListType };
 
         /**
          * Creates a new ClientModFlagsUpdate instance using the specified properties.
@@ -10131,7 +10138,7 @@ export namespace NT {
     interface IServerModFlagsUpdated {
 
         /** ServerModFlagsUpdated modFlags */
-        modFlags?: ({ [k: string]: string }|null);
+        modFlags?: ({ [k: string]: NT.ModFlagsListType }|null);
     }
 
     /** Represents a ServerModFlagsUpdated. */
@@ -10144,7 +10151,7 @@ export namespace NT {
         constructor(properties?: NT.IServerModFlagsUpdated);
 
         /** ServerModFlagsUpdated modFlags. */
-        public modFlags: { [k: string]: string };
+        public modFlags: { [k: string]: NT.ModFlagsListType };
 
         /**
          * Creates a new ServerModFlagsUpdated instance using the specified properties.

--- a/src/pbjs_pb.js
+++ b/src/pbjs_pb.js
@@ -19975,6 +19975,9 @@ $root.NT = (function() {
          * @property {NT.IServerDisconnected|null} [sDisconnected] LobbyAction sDisconnected
          * @property {NT.IServerRoomAddToList|null} [sRoomAddToList] LobbyAction sRoomAddToList
          * @property {NT.IClientRunOver|null} [cRunOver] LobbyAction cRunOver
+         * @property {NT.IClientModFlagsUpdate|null} [cRoomModFlagsUpdate] LobbyAction cRoomModFlagsUpdate
+         * @property {NT.IServerModFlagsUpdated|null} [sRoomModFlagsUpdated] LobbyAction sRoomModFlagsUpdated
+         * @property {NT.IServerModFlagsUpdateFailed|null} [sRoomModFlagsUpdateFailed] LobbyAction sRoomModFlagsUpdateFailed
          */
 
         /**
@@ -20232,17 +20235,41 @@ $root.NT = (function() {
          */
         LobbyAction.prototype.cRunOver = null;
 
+        /**
+         * LobbyAction cRoomModFlagsUpdate.
+         * @member {NT.IClientModFlagsUpdate|null|undefined} cRoomModFlagsUpdate
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.cRoomModFlagsUpdate = null;
+
+        /**
+         * LobbyAction sRoomModFlagsUpdated.
+         * @member {NT.IServerModFlagsUpdated|null|undefined} sRoomModFlagsUpdated
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.sRoomModFlagsUpdated = null;
+
+        /**
+         * LobbyAction sRoomModFlagsUpdateFailed.
+         * @member {NT.IServerModFlagsUpdateFailed|null|undefined} sRoomModFlagsUpdateFailed
+         * @memberof NT.LobbyAction
+         * @instance
+         */
+        LobbyAction.prototype.sRoomModFlagsUpdateFailed = null;
+
         // OneOf field names bound to virtual getters and setters
         var $oneOfFields;
 
         /**
          * LobbyAction action.
-         * @member {"cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|undefined} action
+         * @member {"cRoomCreate"|"sRoomCreated"|"sRoomCreateFailed"|"cRoomUpdate"|"sRoomUpdated"|"sRoomUpdateFailed"|"cRoomFlagsUpdate"|"sRoomFlagsUpdated"|"sRoomFlagsUpdateFailed"|"cRoomDelete"|"sRoomDeleted"|"cJoinRoom"|"sJoinRoomSuccess"|"sJoinRoomFailed"|"sUserJoinedRoom"|"cLeaveRoom"|"sUserLeftRoom"|"cKickUser"|"sUserKicked"|"cBanUser"|"sUserBanned"|"cReadyState"|"sUserReadyState"|"cStartRun"|"sHostStart"|"cRequestRoomList"|"sRoomList"|"sDisconnected"|"sRoomAddToList"|"cRunOver"|"cRoomModFlagsUpdate"|"sRoomModFlagsUpdated"|"sRoomModFlagsUpdateFailed"|undefined} action
          * @memberof NT.LobbyAction
          * @instance
          */
         Object.defineProperty(LobbyAction.prototype, "action", {
-            get: $util.oneOfGetter($oneOfFields = ["cRoomCreate", "sRoomCreated", "sRoomCreateFailed", "cRoomUpdate", "sRoomUpdated", "sRoomUpdateFailed", "cRoomFlagsUpdate", "sRoomFlagsUpdated", "sRoomFlagsUpdateFailed", "cRoomDelete", "sRoomDeleted", "cJoinRoom", "sJoinRoomSuccess", "sJoinRoomFailed", "sUserJoinedRoom", "cLeaveRoom", "sUserLeftRoom", "cKickUser", "sUserKicked", "cBanUser", "sUserBanned", "cReadyState", "sUserReadyState", "cStartRun", "sHostStart", "cRequestRoomList", "sRoomList", "sDisconnected", "sRoomAddToList", "cRunOver"]),
+            get: $util.oneOfGetter($oneOfFields = ["cRoomCreate", "sRoomCreated", "sRoomCreateFailed", "cRoomUpdate", "sRoomUpdated", "sRoomUpdateFailed", "cRoomFlagsUpdate", "sRoomFlagsUpdated", "sRoomFlagsUpdateFailed", "cRoomDelete", "sRoomDeleted", "cJoinRoom", "sJoinRoomSuccess", "sJoinRoomFailed", "sUserJoinedRoom", "cLeaveRoom", "sUserLeftRoom", "cKickUser", "sUserKicked", "cBanUser", "sUserBanned", "cReadyState", "sUserReadyState", "cStartRun", "sHostStart", "cRequestRoomList", "sRoomList", "sDisconnected", "sRoomAddToList", "cRunOver", "cRoomModFlagsUpdate", "sRoomModFlagsUpdated", "sRoomModFlagsUpdateFailed"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -20330,6 +20357,12 @@ $root.NT = (function() {
                 $root.NT.ServerRoomAddToList.encode(message.sRoomAddToList, writer.uint32(/* id 32, wireType 2 =*/258).fork()).ldelim();
             if (message.cRunOver != null && Object.hasOwnProperty.call(message, "cRunOver"))
                 $root.NT.ClientRunOver.encode(message.cRunOver, writer.uint32(/* id 33, wireType 2 =*/266).fork()).ldelim();
+            if (message.cRoomModFlagsUpdate != null && Object.hasOwnProperty.call(message, "cRoomModFlagsUpdate"))
+                $root.NT.ClientModFlagsUpdate.encode(message.cRoomModFlagsUpdate, writer.uint32(/* id 34, wireType 2 =*/274).fork()).ldelim();
+            if (message.sRoomModFlagsUpdated != null && Object.hasOwnProperty.call(message, "sRoomModFlagsUpdated"))
+                $root.NT.ServerModFlagsUpdated.encode(message.sRoomModFlagsUpdated, writer.uint32(/* id 35, wireType 2 =*/282).fork()).ldelim();
+            if (message.sRoomModFlagsUpdateFailed != null && Object.hasOwnProperty.call(message, "sRoomModFlagsUpdateFailed"))
+                $root.NT.ServerModFlagsUpdateFailed.encode(message.sRoomModFlagsUpdateFailed, writer.uint32(/* id 36, wireType 2 =*/290).fork()).ldelim();
             return writer;
         };
 
@@ -20482,6 +20515,18 @@ $root.NT = (function() {
                     }
                 case 33: {
                         message.cRunOver = $root.NT.ClientRunOver.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 34: {
+                        message.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 35: {
+                        message.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 36: {
+                        message.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.decode(reader, reader.uint32());
                         break;
                     }
                 default:
@@ -20818,6 +20863,36 @@ $root.NT = (function() {
                         return "cRunOver." + error;
                 }
             }
+            if (message.cRoomModFlagsUpdate != null && message.hasOwnProperty("cRoomModFlagsUpdate")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ClientModFlagsUpdate.verify(message.cRoomModFlagsUpdate);
+                    if (error)
+                        return "cRoomModFlagsUpdate." + error;
+                }
+            }
+            if (message.sRoomModFlagsUpdated != null && message.hasOwnProperty("sRoomModFlagsUpdated")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ServerModFlagsUpdated.verify(message.sRoomModFlagsUpdated);
+                    if (error)
+                        return "sRoomModFlagsUpdated." + error;
+                }
+            }
+            if (message.sRoomModFlagsUpdateFailed != null && message.hasOwnProperty("sRoomModFlagsUpdateFailed")) {
+                if (properties.action === 1)
+                    return "action: multiple values";
+                properties.action = 1;
+                {
+                    var error = $root.NT.ServerModFlagsUpdateFailed.verify(message.sRoomModFlagsUpdateFailed);
+                    if (error)
+                        return "sRoomModFlagsUpdateFailed." + error;
+                }
+            }
             return null;
         };
 
@@ -20982,6 +21057,21 @@ $root.NT = (function() {
                 if (typeof object.cRunOver !== "object")
                     throw TypeError(".NT.LobbyAction.cRunOver: object expected");
                 message.cRunOver = $root.NT.ClientRunOver.fromObject(object.cRunOver);
+            }
+            if (object.cRoomModFlagsUpdate != null) {
+                if (typeof object.cRoomModFlagsUpdate !== "object")
+                    throw TypeError(".NT.LobbyAction.cRoomModFlagsUpdate: object expected");
+                message.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.fromObject(object.cRoomModFlagsUpdate);
+            }
+            if (object.sRoomModFlagsUpdated != null) {
+                if (typeof object.sRoomModFlagsUpdated !== "object")
+                    throw TypeError(".NT.LobbyAction.sRoomModFlagsUpdated: object expected");
+                message.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.fromObject(object.sRoomModFlagsUpdated);
+            }
+            if (object.sRoomModFlagsUpdateFailed != null) {
+                if (typeof object.sRoomModFlagsUpdateFailed !== "object")
+                    throw TypeError(".NT.LobbyAction.sRoomModFlagsUpdateFailed: object expected");
+                message.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.fromObject(object.sRoomModFlagsUpdateFailed);
             }
             return message;
         };
@@ -21148,6 +21238,21 @@ $root.NT = (function() {
                 object.cRunOver = $root.NT.ClientRunOver.toObject(message.cRunOver, options);
                 if (options.oneofs)
                     object.action = "cRunOver";
+            }
+            if (message.cRoomModFlagsUpdate != null && message.hasOwnProperty("cRoomModFlagsUpdate")) {
+                object.cRoomModFlagsUpdate = $root.NT.ClientModFlagsUpdate.toObject(message.cRoomModFlagsUpdate, options);
+                if (options.oneofs)
+                    object.action = "cRoomModFlagsUpdate";
+            }
+            if (message.sRoomModFlagsUpdated != null && message.hasOwnProperty("sRoomModFlagsUpdated")) {
+                object.sRoomModFlagsUpdated = $root.NT.ServerModFlagsUpdated.toObject(message.sRoomModFlagsUpdated, options);
+                if (options.oneofs)
+                    object.action = "sRoomModFlagsUpdated";
+            }
+            if (message.sRoomModFlagsUpdateFailed != null && message.hasOwnProperty("sRoomModFlagsUpdateFailed")) {
+                object.sRoomModFlagsUpdateFailed = $root.NT.ServerModFlagsUpdateFailed.toObject(message.sRoomModFlagsUpdateFailed, options);
+                if (options.oneofs)
+                    object.action = "sRoomModFlagsUpdateFailed";
             }
             return object;
         };
@@ -25554,6 +25659,685 @@ $root.NT = (function() {
         };
 
         return ServerRoomFlagsUpdateFailed;
+    })();
+
+    NT.ClientModFlagsUpdate = (function() {
+
+        /**
+         * Properties of a ClientModFlagsUpdate.
+         * @memberof NT
+         * @interface IClientModFlagsUpdate
+         * @property {Object.<string,string>|null} [modFlags] ClientModFlagsUpdate modFlags
+         */
+
+        /**
+         * Constructs a new ClientModFlagsUpdate.
+         * @memberof NT
+         * @classdesc Represents a ClientModFlagsUpdate.
+         * @implements IClientModFlagsUpdate
+         * @constructor
+         * @param {NT.IClientModFlagsUpdate=} [properties] Properties to set
+         */
+        function ClientModFlagsUpdate(properties) {
+            this.modFlags = {};
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ClientModFlagsUpdate modFlags.
+         * @member {Object.<string,string>} modFlags
+         * @memberof NT.ClientModFlagsUpdate
+         * @instance
+         */
+        ClientModFlagsUpdate.prototype.modFlags = $util.emptyObject;
+
+        /**
+         * Creates a new ClientModFlagsUpdate instance using the specified properties.
+         * @function create
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate=} [properties] Properties to set
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate instance
+         */
+        ClientModFlagsUpdate.create = function create(properties) {
+            return new ClientModFlagsUpdate(properties);
+        };
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate} message ClientModFlagsUpdate message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ClientModFlagsUpdate.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
+                for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ClientModFlagsUpdate message, length delimited. Does not implicitly {@link NT.ClientModFlagsUpdate.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.IClientModFlagsUpdate} message ClientModFlagsUpdate message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ClientModFlagsUpdate.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ClientModFlagsUpdate.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ClientModFlagsUpdate(), key, value;
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        if (message.modFlags === $util.emptyObject)
+                            message.modFlags = {};
+                        var end2 = reader.uint32() + reader.pos;
+                        key = "";
+                        value = "";
+                        while (reader.pos < end2) {
+                            var tag2 = reader.uint32();
+                            switch (tag2 >>> 3) {
+                            case 1:
+                                key = reader.string();
+                                break;
+                            case 2:
+                                value = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag2 & 7);
+                                break;
+                            }
+                        }
+                        message.modFlags[key] = value;
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ClientModFlagsUpdate message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ClientModFlagsUpdate.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ClientModFlagsUpdate message.
+         * @function verify
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ClientModFlagsUpdate.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.modFlags != null && message.hasOwnProperty("modFlags")) {
+                if (!$util.isObject(message.modFlags))
+                    return "modFlags: object expected";
+                var key = Object.keys(message.modFlags);
+                for (var i = 0; i < key.length; ++i)
+                    if (!$util.isString(message.modFlags[key[i]]))
+                        return "modFlags: string{k:string} expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a ClientModFlagsUpdate message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ClientModFlagsUpdate} ClientModFlagsUpdate
+         */
+        ClientModFlagsUpdate.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ClientModFlagsUpdate)
+                return object;
+            var message = new $root.NT.ClientModFlagsUpdate();
+            if (object.modFlags) {
+                if (typeof object.modFlags !== "object")
+                    throw TypeError(".NT.ClientModFlagsUpdate.modFlags: object expected");
+                message.modFlags = {};
+                for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
+                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ClientModFlagsUpdate message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {NT.ClientModFlagsUpdate} message ClientModFlagsUpdate
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ClientModFlagsUpdate.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.objects || options.defaults)
+                object.modFlags = {};
+            var keys2;
+            if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
+                object.modFlags = {};
+                for (var j = 0; j < keys2.length; ++j)
+                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this ClientModFlagsUpdate to JSON.
+         * @function toJSON
+         * @memberof NT.ClientModFlagsUpdate
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ClientModFlagsUpdate.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ClientModFlagsUpdate
+         * @function getTypeUrl
+         * @memberof NT.ClientModFlagsUpdate
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ClientModFlagsUpdate.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ClientModFlagsUpdate";
+        };
+
+        return ClientModFlagsUpdate;
+    })();
+
+    NT.ServerModFlagsUpdated = (function() {
+
+        /**
+         * Properties of a ServerModFlagsUpdated.
+         * @memberof NT
+         * @interface IServerModFlagsUpdated
+         * @property {Object.<string,string>|null} [modFlags] ServerModFlagsUpdated modFlags
+         */
+
+        /**
+         * Constructs a new ServerModFlagsUpdated.
+         * @memberof NT
+         * @classdesc Represents a ServerModFlagsUpdated.
+         * @implements IServerModFlagsUpdated
+         * @constructor
+         * @param {NT.IServerModFlagsUpdated=} [properties] Properties to set
+         */
+        function ServerModFlagsUpdated(properties) {
+            this.modFlags = {};
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ServerModFlagsUpdated modFlags.
+         * @member {Object.<string,string>} modFlags
+         * @memberof NT.ServerModFlagsUpdated
+         * @instance
+         */
+        ServerModFlagsUpdated.prototype.modFlags = $util.emptyObject;
+
+        /**
+         * Creates a new ServerModFlagsUpdated instance using the specified properties.
+         * @function create
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated=} [properties] Properties to set
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated instance
+         */
+        ServerModFlagsUpdated.create = function create(properties) {
+            return new ServerModFlagsUpdated(properties);
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated} message ServerModFlagsUpdated message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdated.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
+                for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdated message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdated.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.IServerModFlagsUpdated} message ServerModFlagsUpdated message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdated.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdated.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ServerModFlagsUpdated(), key, value;
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        if (message.modFlags === $util.emptyObject)
+                            message.modFlags = {};
+                        var end2 = reader.uint32() + reader.pos;
+                        key = "";
+                        value = "";
+                        while (reader.pos < end2) {
+                            var tag2 = reader.uint32();
+                            switch (tag2 >>> 3) {
+                            case 1:
+                                key = reader.string();
+                                break;
+                            case 2:
+                                value = reader.string();
+                                break;
+                            default:
+                                reader.skipType(tag2 & 7);
+                                break;
+                            }
+                        }
+                        message.modFlags[key] = value;
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdated message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdated.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ServerModFlagsUpdated message.
+         * @function verify
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ServerModFlagsUpdated.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.modFlags != null && message.hasOwnProperty("modFlags")) {
+                if (!$util.isObject(message.modFlags))
+                    return "modFlags: object expected";
+                var key = Object.keys(message.modFlags);
+                for (var i = 0; i < key.length; ++i)
+                    if (!$util.isString(message.modFlags[key[i]]))
+                        return "modFlags: string{k:string} expected";
+            }
+            return null;
+        };
+
+        /**
+         * Creates a ServerModFlagsUpdated message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ServerModFlagsUpdated} ServerModFlagsUpdated
+         */
+        ServerModFlagsUpdated.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ServerModFlagsUpdated)
+                return object;
+            var message = new $root.NT.ServerModFlagsUpdated();
+            if (object.modFlags) {
+                if (typeof object.modFlags !== "object")
+                    throw TypeError(".NT.ServerModFlagsUpdated.modFlags: object expected");
+                message.modFlags = {};
+                for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
+                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdated message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {NT.ServerModFlagsUpdated} message ServerModFlagsUpdated
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ServerModFlagsUpdated.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.objects || options.defaults)
+                object.modFlags = {};
+            var keys2;
+            if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
+                object.modFlags = {};
+                for (var j = 0; j < keys2.length; ++j)
+                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+            }
+            return object;
+        };
+
+        /**
+         * Converts this ServerModFlagsUpdated to JSON.
+         * @function toJSON
+         * @memberof NT.ServerModFlagsUpdated
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ServerModFlagsUpdated.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdated
+         * @function getTypeUrl
+         * @memberof NT.ServerModFlagsUpdated
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ServerModFlagsUpdated.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ServerModFlagsUpdated";
+        };
+
+        return ServerModFlagsUpdated;
+    })();
+
+    NT.ServerModFlagsUpdateFailed = (function() {
+
+        /**
+         * Properties of a ServerModFlagsUpdateFailed.
+         * @memberof NT
+         * @interface IServerModFlagsUpdateFailed
+         * @property {string|null} [reason] ServerModFlagsUpdateFailed reason
+         */
+
+        /**
+         * Constructs a new ServerModFlagsUpdateFailed.
+         * @memberof NT
+         * @classdesc Represents a ServerModFlagsUpdateFailed.
+         * @implements IServerModFlagsUpdateFailed
+         * @constructor
+         * @param {NT.IServerModFlagsUpdateFailed=} [properties] Properties to set
+         */
+        function ServerModFlagsUpdateFailed(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * ServerModFlagsUpdateFailed reason.
+         * @member {string} reason
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @instance
+         */
+        ServerModFlagsUpdateFailed.prototype.reason = "";
+
+        /**
+         * Creates a new ServerModFlagsUpdateFailed instance using the specified properties.
+         * @function create
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed=} [properties] Properties to set
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed instance
+         */
+        ServerModFlagsUpdateFailed.create = function create(properties) {
+            return new ServerModFlagsUpdateFailed(properties);
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @function encode
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdateFailed.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.reason != null && Object.hasOwnProperty.call(message, "reason"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.reason);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified ServerModFlagsUpdateFailed message, length delimited. Does not implicitly {@link NT.ServerModFlagsUpdateFailed.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.IServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        ServerModFlagsUpdateFailed.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer.
+         * @function decode
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdateFailed.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.NT.ServerModFlagsUpdateFailed();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1: {
+                        message.reason = reader.string();
+                        break;
+                    }
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a ServerModFlagsUpdateFailed message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        ServerModFlagsUpdateFailed.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a ServerModFlagsUpdateFailed message.
+         * @function verify
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        ServerModFlagsUpdateFailed.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.reason != null && message.hasOwnProperty("reason"))
+                if (!$util.isString(message.reason))
+                    return "reason: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a ServerModFlagsUpdateFailed message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {NT.ServerModFlagsUpdateFailed} ServerModFlagsUpdateFailed
+         */
+        ServerModFlagsUpdateFailed.fromObject = function fromObject(object) {
+            if (object instanceof $root.NT.ServerModFlagsUpdateFailed)
+                return object;
+            var message = new $root.NT.ServerModFlagsUpdateFailed();
+            if (object.reason != null)
+                message.reason = String(object.reason);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a ServerModFlagsUpdateFailed message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {NT.ServerModFlagsUpdateFailed} message ServerModFlagsUpdateFailed
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        ServerModFlagsUpdateFailed.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults)
+                object.reason = "";
+            if (message.reason != null && message.hasOwnProperty("reason"))
+                object.reason = message.reason;
+            return object;
+        };
+
+        /**
+         * Converts this ServerModFlagsUpdateFailed to JSON.
+         * @function toJSON
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        ServerModFlagsUpdateFailed.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        /**
+         * Gets the default type url for ServerModFlagsUpdateFailed
+         * @function getTypeUrl
+         * @memberof NT.ServerModFlagsUpdateFailed
+         * @static
+         * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+         * @returns {string} The default type url
+         */
+        ServerModFlagsUpdateFailed.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+            if (typeUrlPrefix === undefined) {
+                typeUrlPrefix = "type.googleapis.com";
+            }
+            return typeUrlPrefix + "/NT.ServerModFlagsUpdateFailed";
+        };
+
+        return ServerModFlagsUpdateFailed;
     })();
 
     NT.ClientJoinRoom = (function() {

--- a/src/pbjs_pb.js
+++ b/src/pbjs_pb.js
@@ -25661,13 +25661,29 @@ $root.NT = (function() {
         return ServerRoomFlagsUpdateFailed;
     })();
 
+    /**
+     * ModFlagsListType enum.
+     * @name NT.ModFlagsListType
+     * @enum {number}
+     * @property {number} UNSPECIFIED=0 UNSPECIFIED value
+     * @property {number} ALLOWED=1 ALLOWED value
+     * @property {number} DENIED=2 DENIED value
+     */
+    NT.ModFlagsListType = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "UNSPECIFIED"] = 0;
+        values[valuesById[1] = "ALLOWED"] = 1;
+        values[valuesById[2] = "DENIED"] = 2;
+        return values;
+    })();
+
     NT.ClientModFlagsUpdate = (function() {
 
         /**
          * Properties of a ClientModFlagsUpdate.
          * @memberof NT
          * @interface IClientModFlagsUpdate
-         * @property {Object.<string,string>|null} [modFlags] ClientModFlagsUpdate modFlags
+         * @property {Object.<string,NT.ModFlagsListType>|null} [modFlags] ClientModFlagsUpdate modFlags
          */
 
         /**
@@ -25688,7 +25704,7 @@ $root.NT = (function() {
 
         /**
          * ClientModFlagsUpdate modFlags.
-         * @member {Object.<string,string>} modFlags
+         * @member {Object.<string,NT.ModFlagsListType>} modFlags
          * @memberof NT.ClientModFlagsUpdate
          * @instance
          */
@@ -25720,7 +25736,7 @@ $root.NT = (function() {
                 writer = $Writer.create();
             if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
                 for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.modFlags[keys[i]]).ldelim();
             return writer;
         };
 
@@ -25760,7 +25776,7 @@ $root.NT = (function() {
                             message.modFlags = {};
                         var end2 = reader.uint32() + reader.pos;
                         key = "";
-                        value = "";
+                        value = 0;
                         while (reader.pos < end2) {
                             var tag2 = reader.uint32();
                             switch (tag2 >>> 3) {
@@ -25768,7 +25784,7 @@ $root.NT = (function() {
                                 key = reader.string();
                                 break;
                             case 2:
-                                value = reader.string();
+                                value = reader.int32();
                                 break;
                             default:
                                 reader.skipType(tag2 & 7);
@@ -25818,8 +25834,14 @@ $root.NT = (function() {
                     return "modFlags: object expected";
                 var key = Object.keys(message.modFlags);
                 for (var i = 0; i < key.length; ++i)
-                    if (!$util.isString(message.modFlags[key[i]]))
-                        return "modFlags: string{k:string} expected";
+                    switch (message.modFlags[key[i]]) {
+                    default:
+                        return "modFlags: enum value{k:string} expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
             }
             return null;
         };
@@ -25841,7 +25863,26 @@ $root.NT = (function() {
                     throw TypeError(".NT.ClientModFlagsUpdate.modFlags: object expected");
                 message.modFlags = {};
                 for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
-                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+                    switch (object.modFlags[keys[i]]) {
+                    default:
+                        if (typeof object.modFlags[keys[i]] === "number") {
+                            message.modFlags[keys[i]] = object.modFlags[keys[i]];
+                            break;
+                        }
+                        break;
+                    case "UNSPECIFIED":
+                    case 0:
+                        message.modFlags[keys[i]] = 0;
+                        break;
+                    case "ALLOWED":
+                    case 1:
+                        message.modFlags[keys[i]] = 1;
+                        break;
+                    case "DENIED":
+                    case 2:
+                        message.modFlags[keys[i]] = 2;
+                        break;
+                    }
             }
             return message;
         };
@@ -25865,7 +25906,7 @@ $root.NT = (function() {
             if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
                 object.modFlags = {};
                 for (var j = 0; j < keys2.length; ++j)
-                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+                    object.modFlags[keys2[j]] = options.enums === String ? $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] === undefined ? message.modFlags[keys2[j]] : $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] : message.modFlags[keys2[j]];
             }
             return object;
         };
@@ -25905,7 +25946,7 @@ $root.NT = (function() {
          * Properties of a ServerModFlagsUpdated.
          * @memberof NT
          * @interface IServerModFlagsUpdated
-         * @property {Object.<string,string>|null} [modFlags] ServerModFlagsUpdated modFlags
+         * @property {Object.<string,NT.ModFlagsListType>|null} [modFlags] ServerModFlagsUpdated modFlags
          */
 
         /**
@@ -25926,7 +25967,7 @@ $root.NT = (function() {
 
         /**
          * ServerModFlagsUpdated modFlags.
-         * @member {Object.<string,string>} modFlags
+         * @member {Object.<string,NT.ModFlagsListType>} modFlags
          * @memberof NT.ServerModFlagsUpdated
          * @instance
          */
@@ -25958,7 +25999,7 @@ $root.NT = (function() {
                 writer = $Writer.create();
             if (message.modFlags != null && Object.hasOwnProperty.call(message, "modFlags"))
                 for (var keys = Object.keys(message.modFlags), i = 0; i < keys.length; ++i)
-                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.modFlags[keys[i]]).ldelim();
+                    writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.modFlags[keys[i]]).ldelim();
             return writer;
         };
 
@@ -25998,7 +26039,7 @@ $root.NT = (function() {
                             message.modFlags = {};
                         var end2 = reader.uint32() + reader.pos;
                         key = "";
-                        value = "";
+                        value = 0;
                         while (reader.pos < end2) {
                             var tag2 = reader.uint32();
                             switch (tag2 >>> 3) {
@@ -26006,7 +26047,7 @@ $root.NT = (function() {
                                 key = reader.string();
                                 break;
                             case 2:
-                                value = reader.string();
+                                value = reader.int32();
                                 break;
                             default:
                                 reader.skipType(tag2 & 7);
@@ -26056,8 +26097,14 @@ $root.NT = (function() {
                     return "modFlags: object expected";
                 var key = Object.keys(message.modFlags);
                 for (var i = 0; i < key.length; ++i)
-                    if (!$util.isString(message.modFlags[key[i]]))
-                        return "modFlags: string{k:string} expected";
+                    switch (message.modFlags[key[i]]) {
+                    default:
+                        return "modFlags: enum value{k:string} expected";
+                    case 0:
+                    case 1:
+                    case 2:
+                        break;
+                    }
             }
             return null;
         };
@@ -26079,7 +26126,26 @@ $root.NT = (function() {
                     throw TypeError(".NT.ServerModFlagsUpdated.modFlags: object expected");
                 message.modFlags = {};
                 for (var keys = Object.keys(object.modFlags), i = 0; i < keys.length; ++i)
-                    message.modFlags[keys[i]] = String(object.modFlags[keys[i]]);
+                    switch (object.modFlags[keys[i]]) {
+                    default:
+                        if (typeof object.modFlags[keys[i]] === "number") {
+                            message.modFlags[keys[i]] = object.modFlags[keys[i]];
+                            break;
+                        }
+                        break;
+                    case "UNSPECIFIED":
+                    case 0:
+                        message.modFlags[keys[i]] = 0;
+                        break;
+                    case "ALLOWED":
+                    case 1:
+                        message.modFlags[keys[i]] = 1;
+                        break;
+                    case "DENIED":
+                    case 2:
+                        message.modFlags[keys[i]] = 2;
+                        break;
+                    }
             }
             return message;
         };
@@ -26103,7 +26169,7 @@ $root.NT = (function() {
             if (message.modFlags && (keys2 = Object.keys(message.modFlags)).length) {
                 object.modFlags = {};
                 for (var j = 0; j < keys2.length; ++j)
-                    object.modFlags[keys2[j]] = message.modFlags[keys2[j]];
+                    object.modFlags[keys2[j]] = options.enums === String ? $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] === undefined ? message.modFlags[keys2[j]] : $root.NT.ModFlagsListType[message.modFlags[keys2[j]]] : message.modFlags[keys2[j]];
             }
             return object;
         };

--- a/src/pbjs_pb.json
+++ b/src/pbjs_pb.json
@@ -2171,11 +2171,18 @@
             }
           }
         },
+        "ModFlagsListType": {
+          "values": {
+            "UNSPECIFIED": 0,
+            "ALLOWED": 1,
+            "DENIED": 2
+          }
+        },
         "ClientModFlagsUpdate": {
           "fields": {
             "modFlags": {
               "keyType": "string",
-              "type": "string",
+              "type": "ModFlagsListType",
               "id": 1
             }
           }
@@ -2184,7 +2191,7 @@
           "fields": {
             "modFlags": {
               "keyType": "string",
-              "type": "string",
+              "type": "ModFlagsListType",
               "id": 1
             }
           }

--- a/src/pbjs_pb.json
+++ b/src/pbjs_pb.json
@@ -1574,7 +1574,10 @@
                 "sRoomList",
                 "sDisconnected",
                 "sRoomAddToList",
-                "cRunOver"
+                "cRunOver",
+                "cRoomModFlagsUpdate",
+                "sRoomModFlagsUpdated",
+                "sRoomModFlagsUpdateFailed"
               ]
             }
           },
@@ -1698,6 +1701,18 @@
             "cRunOver": {
               "type": "ClientRunOver",
               "id": 33
+            },
+            "cRoomModFlagsUpdate": {
+              "type": "ClientModFlagsUpdate",
+              "id": 34
+            },
+            "sRoomModFlagsUpdated": {
+              "type": "ServerModFlagsUpdated",
+              "id": 35
+            },
+            "sRoomModFlagsUpdateFailed": {
+              "type": "ServerModFlagsUpdateFailed",
+              "id": 36
             }
           }
         },
@@ -2149,6 +2164,32 @@
           }
         },
         "ServerRoomFlagsUpdateFailed": {
+          "fields": {
+            "reason": {
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ClientModFlagsUpdate": {
+          "fields": {
+            "modFlags": {
+              "keyType": "string",
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ServerModFlagsUpdated": {
+          "fields": {
+            "modFlags": {
+              "keyType": "string",
+              "type": "string",
+              "id": 1
+            }
+          }
+        },
+        "ServerModFlagsUpdateFailed": {
           "fields": {
             "reason": {
               "type": "string",

--- a/src/pbreflect.ts
+++ b/src/pbreflect.ts
@@ -2,24 +2,43 @@ import def from './pbjs_pb.json';
 const NT = def.nested.NT.nested;
 
 type FieldList = { [key: string]: { type: string; id: number } };
+type ValuesList = { [key: string]: number };
+
 type FieldIds<T extends FieldList> = { [K in keyof T]: T[K]['id'] } & unknown;
-type MessageIds<T extends { [key in keyof T]: { fields: FieldList } }> = {
-  [K in keyof T]: FieldIds<T[K]['fields']>;
+type ValueIds<T extends ValuesList> = { [K in keyof T]: T[K] } & unknown;
+
+type FieldDef = { fields: FieldList; [key: string]: any};
+type EnumDef = { values: ValuesList; [key: string]: any};
+type MessageDef = FieldDef | EnumDef;
+
+type MessageIds<T> = {
+  [K in keyof T]: T[K] extends { fields: FieldList } 
+    ? FieldIds<T[K]['fields']> 
+    : T[K] extends { values: ValuesList }
+      ? ValueIds<T[K]['values']>
+      : never;
 } & unknown;
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 
-export const Messages: MessageIds<typeof NT> = Object.create(null) as any;
-for (const [msgName, defs] of Object.entries(NT) as [keyof typeof NT, (typeof NT)[keyof typeof NT]][]) {
-  if (!defs.fields) continue;
-
-  const fields: UnionToIntersection<FieldIds<typeof defs.fields>> = Object.create(null) as any;
-  for (const [fieldName, nameid] of Object.entries(defs.fields) as [keyof typeof fields, { id: number }][]) {
-    fields[fieldName] = nameid.id;
+const MessagesImpl = Object.create(null) as any;
+for (const [msgName, defs] of Object.entries(NT) as [keyof typeof NT, MessageDef][]) {
+  if ('fields' in defs) {
+    const fields: UnionToIntersection<FieldIds<typeof defs.fields>> = Object.create(null) as any;
+    for (const [fieldName, nameid] of Object.entries(defs.fields) as [string, { id: number }][]) {
+      fields[fieldName] = nameid.id;
+    }
+    MessagesImpl[msgName] = fields;
+  } else if ('values' in defs) {
+    const values: ValueIds<typeof defs.values> = Object.create(null) as any;
+    for (const [valueName, valueId] of Object.entries(defs.values)) {
+      values[valueName] = valueId;
+    }
+    MessagesImpl[msgName] = values;
   }
-  Messages[msgName] = fields;
 }
 
+export const Messages = MessagesImpl as MessageIds<typeof NT>;
 export const gameActions = Object.keys(
   def.nested.NT.nested.GameAction.fields
 ) as (keyof typeof def.nested.NT.nested.GameAction.fields)[];


### PR DESCRIPTION
# Add Support for Mod Flags

## Overview
Adds support for mod flags functionality in Noita Together. 

## Changes
- Utilized Amazon Q to add a Windows-compatible build script `yarn build_windows`
- Added new message types to `nt-message\proto\messages.proto` in the LobbyAction namespace:
  - `ClientModFlagsUpdate`: Allows nt-app to send mod flag updates to the lobby-server
  - `ServerModFlagsUpdated`: Allows lobby-server to send updates to nt-app
  - `ServerModFlagsUpdateFailed`: Allows lobby-server to send error response when mod flag updates fail to nt-app.
- Implemented a `Map<string, string>` structure for mod flags using `[modName, listName]` pairs
- TypeScript definitions were auto-updated from `yarn build_windows`

## Testing
Testing was performed locally by running the nt auth and lobby servers while testing with two nt apps running. One on Windows and one on Linux (via WSL).

Demo of changes
https://youtu.be/GF4rYNdBwTw

## Related PRs
- lobby-server PR: https://github.com/Noita-Together/lobby-server/pull/12
- noita-together PR: https://github.com/Noita-Together/noita-together/pull/228
